### PR TITLE
Run multicluster tests in the nightly pipeline

### DIFF
--- a/main/pipeline.yaml
+++ b/main/pipeline.yaml
@@ -59,6 +59,8 @@ spec:
           value: $(params.make-target)
         - name: additional-env
           value: $(params.additional-env)
+        - name: kubeconfig-path
+          value: $(tasks.kubectl-login.results.kubeconfig-path)
       runAfter:
         - kubectl-login
       taskRef:

--- a/nightly/eventlistener.yaml
+++ b/nightly/eventlistener.yaml
@@ -8,13 +8,15 @@ spec:
     - name: nightly-kuadrant-trigger
       bindings:
         - name: kube-api
-          value: https://api.kuadrant.example.io:6443
+          value: https://api.kuadrant-1.example.io:6443
         - name: project
           value: kuadrant
         - name: make-target
           value: all
         - name: additional-env
           value: ""
+        - name: kube-api-second
+          value: https://api.kuadrant-2.example.io:6443
         - name: launch-name
           value: nightly
         - name: rp-project
@@ -28,6 +30,7 @@ spec:
             - name: project
             - name: make-target
             - name: additional-env
+            - name: kube-api-second
             - name: launch-name
             - name: rp-project
             - name: upload-results
@@ -48,6 +51,8 @@ spec:
                     value: $(tt.params.make-target)
                   - name: additional-env
                     value: $(tt.params.additional-env)
+                  - name: kube-api-second
+                    value: $(tt.params.kube-api-second)
                   - name: launch-name
                     value: $(tt.params.launch-name)
                   - name: rp-project

--- a/nightly/pipeline.yaml
+++ b/nightly/pipeline.yaml
@@ -23,6 +23,9 @@ spec:
       description: Additional env for testsuite container separated with spaces (e.g. KUADRANT_CONTROL_PLANE__provider_secret=gcp-credentials KUADRANT_KEYCLOAK__url="https://my-sso.net")
       name: additional-env
       type: string
+    - description: API URL of the second Openshift cluster for multi-cluster tests
+      name: kube-api-second
+      type: string
     - default: nightly
       description: Prefix of the launch name saved in report portal (nightly, username, manual, etc.)
       name: launch-name
@@ -59,6 +62,8 @@ spec:
           value: kuadrant
         - name: additional-env
           value: $(params.additional-env)
+        - name: kubeconfig-path
+          value: $(tasks.kubectl-login.results.kubeconfig-path)
       runAfter:
         - kubectl-login
       taskRef:
@@ -78,8 +83,43 @@ spec:
           value: authorino-standalone
         - name: additional-env
           value: $(params.additional-env)
+        - name: kubeconfig-path
+          value: $(tasks.kubectl-login.results.kubeconfig-path)
       runAfter:
         - run-tests-kuadrant
+      taskRef:
+        kind: Task
+        name: run-tests
+      workspaces:
+        - name: shared-workspace
+    - name: kubectl-login-second-cluster
+      params:
+        - name: testsuite-image
+          value: $(params.testsuite-image)
+        - name: kube-api
+          value: $(params.kube-api-second)
+      taskRef:
+        kind: Task
+        name: kubectl-login
+      workspaces:
+        - name: shared-workspace
+    - name: run-tests-multicluster
+      params:
+        - name: testsuite-image
+          value: $(params.testsuite-image)
+        - name: kube-api
+          value: $(params.kube-api)
+        - name: project
+          value: $(params.project)
+        - name: make-target
+          value: multicluster
+        - name: additional-env
+          value: '$(params.additional-env) KUADRANT_CONTROL_PLANE__additional_clusters="@json [{\"kubeconfig_path\": \"$(tasks.kubectl-login-second-cluster.results.kubeconfig-path)\"}]"'
+        - name: kubeconfig-path
+          value: $(tasks.kubectl-login.results.kubeconfig-path)
+      runAfter:
+        - kubectl-login-second-cluster
+        - run-tests-authorino-standalone
       taskRef:
         kind: Task
         name: run-tests
@@ -97,8 +137,10 @@ spec:
           value: dnstls
         - name: additional-env
           value: "$(params.additional-env) KUADRANT_CONTROL_PLANE__provider_secret=gcp-credentials"
+        - name: kubeconfig-path
+          value: $(tasks.kubectl-login.results.kubeconfig-path)
       runAfter:
-        - run-tests-authorino-standalone
+        - run-tests-multicluster
       taskRef:
         kind: Task
         name: run-tests

--- a/tasks/kubectl-login-task.yaml
+++ b/tasks/kubectl-login-task.yaml
@@ -10,15 +10,21 @@ spec:
     - description: API URL of the Openshift cluster
       name: kube-api
       type: string
+  results:
+    - name: kubeconfig-path
+      description: Path to new kubeconfig in the workspace
   steps:
     - args:
         - >-
+          export CLUSTER_NAME=$(echo $(params.kube-api) | sed 's/.*api\.\([^\.]*\).*/\1/') &&
+          export KUBECONFIG=$(workspaces.shared-workspace.path)/${CLUSTER_NAME} &&
           export OAUTH_URL=$(echo $(params.kube-api) | sed -e 's/api/oauth-openshift.apps/' -e 's/\(.*\):.*/\1/')/oauth/authorize &&
           export TOKEN=$(curl -XPOST -kis --data response_type=token --data client_id=openshift-challenging-client -u ${KUBE_USER}:${KUBE_PASSWORD} ${OAUTH_URL} | grep "Location:" | sed 's/.*access_token=\([^&]*\).*/\1/') &&
           kubectl config set-cluster ctx --server $(params.kube-api) --insecure-skip-tls-verify=true &&
           kubectl config set-credentials user --token=${TOKEN} &&
           kubectl config set-context ctx --user=user --cluster=ctx &&
-          kubectl config use-context ctx
+          kubectl config use-context ctx &&
+          echo -n ${KUBECONFIG} | tee $(results.kubeconfig-path.path)
       command:
         - /bin/bash
         - -cveo
@@ -28,8 +34,6 @@ spec:
           cpu: '250m'
           memory: 128Mi
       env:
-        - name: KUBECONFIG
-          value: $(workspaces.shared-workspace.path)/kubeconfig
         - name: WORKSPACE
           value: $(workspaces.shared-workspace.path)
         - name: KUBE_USER

--- a/tasks/run-tests-task.yaml
+++ b/tasks/run-tests-task.yaml
@@ -19,6 +19,9 @@ spec:
     - description: Additional env for testsuite container separated with spaces (e.g. KUADRANT_CONTROL_PLANE__provider_secret=gcp-credentials KUADRANT_KEYCLOAK__url="https://my-sso.net")
       name: additional-env
       type: string
+    - description: Path to workspace kubeconfig (required to store multiple clusters in the workspace for multi-cluster tests)
+      name: kubeconfig-path
+      type: string
   steps:
     - args:
         - >-
@@ -33,7 +36,7 @@ spec:
           memory: 1000Mi
       env:
         - name: KUBECONFIG
-          value: $(workspaces.shared-workspace.path)/kubeconfig
+          value: $(params.kubeconfig-path)
         - name: WORKSPACE
           value: $(workspaces.shared-workspace.path)
         - name: KUADRANT_cluster__project


### PR DESCRIPTION
Add kubeconfig path parameter to run-tests task to support multiple kubeconfigs for multicluster tests

Closes #29 