### PR TITLE
Increase timeout to 2h

### DIFF
--- a/nightly/eventlistener.yaml
+++ b/nightly/eventlistener.yaml
@@ -42,6 +42,8 @@ spec:
               spec:
                 pipelineRef:
                   name: nightly-pipeline
+                timeouts:
+                  pipeline: 2h0m0s
                 params:
                   - name: kube-api
                     value: $(tt.params.kube-api)


### PR DESCRIPTION
The `test` make target can take longer than default 1h timeout.

Documentation:
https://tekton.dev/docs/pipelines/pipelines/#configuring-the-failure-timeout

https://tekton.dev/docs/pipelines/pipelineruns/#configuring-a-failure-timeout

## Verification Steps

Apply the pipelines to some cluster (other than the one where nightlies rue) and validate that the timeout is set as expected