### PR TITLE
Add dnstls-azure task to the nightly pipeline

### DIFF
--- a/main/pipeline.yaml
+++ b/main/pipeline.yaml
@@ -19,6 +19,10 @@ spec:
       description: Makefile target for tests
       name: make-target
       type: string
+    - default: ""
+      description: Pytest flags to use with Make (flags="${pytest-flags}" make kuadrant)
+      name: pytest-flags
+      type: string
     - default: pipeline-settings
       description: Config Map with settings for the testsuite
       name: settings-cm
@@ -59,6 +63,8 @@ spec:
           value: $(params.project)
         - name: make-target
           value: $(params.make-target)
+        - name: pytest-flags
+          value: $(params.pytest-flags)
         - name: settings-cm
           value: $(params.settings-cm)
         - name: additional-env

--- a/nightly/eventlistener.yaml
+++ b/nightly/eventlistener.yaml
@@ -13,6 +13,8 @@ spec:
           value: kuadrant
         - name: make-target
           value: all
+        - name: pytest-flags
+          value: ""
         - name: settings-cm
           value: pipeline-settings
         - name: additional-env

--- a/nightly/pipeline.yaml
+++ b/nightly/pipeline.yaml
@@ -19,6 +19,10 @@ spec:
       description: Makefile target for tests (doesn't affect nightly pipeline, kept for compatibility)
       name: make-target
       type: string
+    - default: ""
+      description: Pytest flags to use with Make (flags="${pytest-flags}" make kuadrant)
+      name: pytest-flags
+      type: string
     - default: pipeline-settings
       description: Config Map with settings for the testsuite
       name: settings-cm
@@ -62,6 +66,8 @@ spec:
           value: $(params.project)
         - name: make-target
           value: kuadrant
+        - name: pytest-flags
+          value: $(params.pytest-flags)
         - name: settings-cm
           value: $(params.settings-cm)
         - name: additional-env
@@ -83,6 +89,8 @@ spec:
           value: $(params.project)
         - name: make-target
           value: authorino-standalone
+        - name: pytest-flags
+          value: $(params.pytest-flags)
         - name: settings-cm
           value: $(params.settings-cm)
         - name: additional-env
@@ -117,6 +125,8 @@ spec:
           value: $(params.settings-cm)
         - name: make-target
           value: multicluster
+        - name: pytest-flags
+          value: $(params.pytest-flags)
         - name: additional-env
           value: '$(params.additional-env) KUADRANT_CONTROL_PLANE__cluster2__kubeconfig_path=$(tasks.kubectl-login-second-cluster.results.kubeconfig-path)'
         - name: kubeconfig-path
@@ -137,6 +147,8 @@ spec:
           value: $(params.project)
         - name: make-target
           value: dnstls
+        - name: pytest-flags
+          value: "$(params.pytest-flags) --junitxml=$(workspaces.shared-workspace.path)/junit-dnstls-gcp.xml -o junit_suite_name=dnstls-gcp"
         - name: settings-cm
           value: $(params.settings-cm)
         - name: additional-env
@@ -145,6 +157,29 @@ spec:
           value: $(tasks.kubectl-login.results.kubeconfig-path)
       runAfter:
         - run-tests-multicluster
+      taskRef:
+        kind: Task
+        name: run-tests
+      workspaces:
+        - name: shared-workspace
+    - name: run-tests-dnstls-azure
+      params:
+        - name: testsuite-image
+          value: $(params.testsuite-image)
+        - name: project
+          value: $(params.project)
+        - name: make-target
+          value: dnstls
+        - name: pytest-flags
+          value: "$(params.pytest-flags) --junitxml=$(workspaces.shared-workspace.path)/junit-dnstls-azure.xml -o junit_suite_name=dnstls-azure"
+        - name: settings-cm
+          value: $(params.settings-cm)
+        - name: additional-env
+          value: "$(params.additional-env) KUADRANT_CONTROL_PLANE__provider_secret=azure-credentials"
+        - name: kubeconfig-path
+          value: $(tasks.kubectl-login.results.kubeconfig-path)
+      runAfter:
+        - run-tests-dnstls-gcp
       taskRef:
         kind: Task
         name: run-tests

--- a/tasks/run-tests-task.yaml
+++ b/tasks/run-tests-task.yaml
@@ -13,6 +13,9 @@ spec:
     - description: Makefile target for tests
       name: make-target
       type: string
+    - description: Pytest flags to use with Make (flags="${pytest-flags}" make kuadrant)
+      name: pytest-flags
+      type: string
     - description: Config Map with settings for the testsuite
       name: settings-cm
       type: string
@@ -26,7 +29,7 @@ spec:
     - args:
         - >-
           cp /var/kuadrant-settings/settings.local.yaml /opt/workdir/kuadrant-testsuite/config &&
-          export $(params.additional-env) &> /dev/null && (flags="-vv" make $(params.make-target) || true)
+          export $(params.additional-env) &> /dev/null && (flags="-vv $(params.pytest-flags)" make $(params.make-target) || true)
       command:
         - /bin/bash
         - -cveo


### PR DESCRIPTION
- Add new dnstls make target task with azure as DNS provider
- Add a feature to append pytest parameters for testsuite execution

Closes #46 