### PR TITLE
Pipeline to provision OSD on AWS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM registry.redhat.io/ubi8/ubi-minimal:latest
+
+RUN curl -Lso ocm https://github.com/openshift-online/ocm-cli/releases/download/v1.0.3/ocm-linux-amd64 && chmod +x ocm && mv ocm /usr/local/bin && microdnf install jq

--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@ Deployment
 ---
 1. Install the `openshift-pipelines` Openshift operator on the cluster
 2. Create required pipelines and their resources
-   * Apply main pipeline `oc apply -k main/ -n ${PIPELINE_NAMESPACE}`
-   * Apply nightly pipeline `oc apply -k nightly/ -n ${PIPELINE_NAMESPACE}`
-   * Apply helm-deploy pipelines `oc apply -k deploy/ -n ${PIPELINE_NAMESPACE}`
+   * Apply main pipeline `kubectl apply -k main/ -n ${PIPELINE_NAMESPACE}`
+   * Apply nightly pipeline `kubectl apply -k nightly/ -n ${PIPELINE_NAMESPACE}`
+   * Apply helm-deploy pipelines `kubectl apply -k deploy/ -n ${PIPELINE_NAMESPACE}`
+   * Apply infrastructure pipelines `kubectl apply -k infra/ -n ${PIPELINE_NAMESPACE}`
 
 Secrets
 ---
@@ -35,6 +36,17 @@ kubectl create cm pipeline-settings --from-file=settings.local.yaml=./settings.l
 - Opaque Secret named values-additional-manifests containing secrets for testsuite run. Example: https://github.com/azgabur/kuadrant-helm-install/blob/main/example-additionalManifests.yaml
 ```shell
 kubectl create -n ${PIPELINE_NAMESPACE} secret generic values-additional-manifests --from-file=additionalManifests.yaml=${ADDITIONAL_MANIFESTS.yaml}
+```
+
+Resources required for infrastructure pipelines:
+- Opaque secret containing AWS credentials for `osdCcsAdmin` IAM user (pipelines provisioning clusters in AWS only). E.g.
+```shell
+kubectl create secret generic kua-aws-credentials --from-literal=AWS_ACCOUNT_ID="xxx" --from-literal=AWS_ACCESS_KEY_ID="xxx" --from-literal=AWS_SECRET_ACCESS_KEY="xxx" -n ${PIPELINE_NAMESPACE}
+```
+
+- Opaque secret containing HCC client credentials (pipelines provisioning clusters via HCC (OCM) only). E.g.
+```shell
+kubectl create secret generic kua-ocm-stage-client-credentials --from-literal=CLIENT_ID="xxx" --from-literal=CLIENT_SECRET="xxx" -n ${PIPELINE_NAMESPACE}
 ```
 
 Pipeline execution

--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ kubectl create secret generic kua-aws-credentials --from-literal=AWS_ACCOUNT_ID=
 kubectl create secret generic kua-ocm-stage-client-credentials --from-literal=CLIENT_ID="xxx" --from-literal=CLIENT_SECRET="xxx" -n ${PIPELINE_NAMESPACE}
 ```
 
+- Opaque secret containing GCP credentials for `osd-ccs-admin` IAM user (pipelines provisioning clusters in GCP only). E.g.
+```shell
+kubectl create secret generic kua-gcp-credentials --from-file=gcp-osd-ccs-admin-sa-security-key.json -n ${PIPELINE_NAMESPACE}
+```
+
 Pipeline execution
 ---
 1. Through the OpenShift Web Console

--- a/infra/delete-osd-pipeline.yaml
+++ b/infra/delete-osd-pipeline.yaml
@@ -1,0 +1,54 @@
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: delete-osd
+spec:
+  description: Delete OSD cluster
+  params:
+    - default: kua-ocm-stage-client-credentials
+      description: Name of secret that contains client ID and client secret to log into OCM org
+      name: ocm-credentials
+      type: string
+    - default: staging
+      description: 'What OCM instance to use, either ''staging'' or ''production'''
+      name: ocm-instance
+      type: string
+    - description: OSD cluster ID that is to be deleted
+      name: cluster-id
+      type: string
+  tasks:
+    - name: ocm-login
+      params:
+        - name: ocm-instance
+          value: $(params.ocm-instance)
+        - name: ocm-credentials
+          value: $(params.ocm-credentials)
+      taskRef:
+        kind: Task
+        name: ocm-login
+      workspaces:
+        - name: shared-workspace
+    - name: delete-osd
+      params:
+        - name: cluster-id
+          value: $(params.cluster-id)
+      taskRef:
+        kind: Task
+        name: delete-osd
+      runAfter:
+        - ocm-login
+      workspaces:
+        - name: shared-workspace
+    - name: wait-till-osd-is-deleted
+      params:
+        - name: cluster-id
+          value: $(params.cluster-id)
+      taskRef:
+        kind: Task
+        name: wait-till-osd-is-deleted
+      runAfter:
+        - delete-osd
+      workspaces:
+        - name: shared-workspace
+  workspaces:
+    - name: shared-workspace

--- a/infra/kustomization.yaml
+++ b/infra/kustomization.yaml
@@ -7,3 +7,4 @@ commonLabels:
 resources:
   - ../tasks/infra/
   - osd-aws-pipeline.yaml
+  - delete-osd-pipeline.yaml

--- a/infra/kustomization.yaml
+++ b/infra/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - ../tasks/infra/
   - osd-aws-pipeline.yaml
   - delete-osd-pipeline.yaml
+  - osd-gcp-pipeline.yaml

--- a/infra/kustomization.yaml
+++ b/infra/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+commonLabels:
+  deployment: kuadrant-qe-pipeline-infra
+
+resources:
+  - ../tasks/infra/
+  - osd-aws-pipeline.yaml

--- a/infra/osd-aws-pipeline.yaml
+++ b/infra/osd-aws-pipeline.yaml
@@ -63,5 +63,16 @@ spec:
         - provision-osd-aws
       workspaces:
         - name: shared-workspace
+    - name: get-osd-credentials
+      params:
+        - name: cluster-id
+          value: $(tasks.provision-osd-aws.results.cluster-id)
+      taskRef:
+        kind: Task
+        name: get-osd-credentials
+      runAfter:
+        - wait-till-osd-is-ready
+      workspaces:
+        - name: shared-workspace
   workspaces:
     - name: shared-workspace

--- a/infra/osd-aws-pipeline.yaml
+++ b/infra/osd-aws-pipeline.yaml
@@ -1,0 +1,67 @@
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: provision-osd-aws
+spec:
+  description: Provision OSD on AWS
+  params:
+    - default: kua-aws-credentials
+      description: Name of secret that contains credentials for osdCcsAdmin
+      name: aws-credentials
+      type: string
+    - default: kua-ocm-stage-client-credentials
+      description: Name of secret that contains client ID and client secret to log into OCM org
+      name: ocm-credentials
+      type: string
+    - default: staging
+      description: 'What OCM instance to use, either ''staging'' or ''production'''
+      name: ocm-instance
+      type: string
+    - default: kua-test
+      description: OSD cluster name
+      name: cluster-name
+      type: string
+    - default: '--provider=aws --ccs --channel-group=stable --compute-machine-type=m5.xlarge --compute-nodes=3 --enable-autoscaling=false --multi-az=false --region=us-east-1 --version=4.17.12 --machine-cidr=10.11.128.0/23 --pod-cidr=10.11.64.0/18 --service-cidr=10.11.0.0/18 --host-prefix=23'
+      description: 'Flags to be used for `ocm create cluster [:osd-name]` command. Do not provide --aws-* flags here.'
+      name: create-cmd-flags
+      type: string
+  tasks:
+    - name: ocm-login
+      params:
+        - name: ocm-instance
+          value: $(params.ocm-instance)
+        - name: ocm-credentials
+          value: $(params.ocm-credentials)
+      taskRef:
+        kind: Task
+        name: ocm-login
+      workspaces:
+        - name: shared-workspace
+    - name: provision-osd-aws
+      params:
+        - name: aws-credentials
+          value: $(params.aws-credentials)
+        - name: create-cmd-flags
+          value: $(params.create-cmd-flags)
+        - name: cluster-name
+          value: $(params.cluster-name)
+      taskRef:
+        kind: Task
+        name: provision-osd-aws
+      runAfter:
+        - ocm-login
+      workspaces:
+        - name: shared-workspace
+    - name: wait-till-osd-is-ready
+      params:
+        - name: cluster-id
+          value: $(tasks.provision-osd-aws.results.cluster-id)
+      taskRef:
+        kind: Task
+        name: wait-till-osd-is-ready
+      runAfter:
+        - provision-osd-aws
+      workspaces:
+        - name: shared-workspace
+  workspaces:
+    - name: shared-workspace

--- a/infra/osd-gcp-pipeline.yaml
+++ b/infra/osd-gcp-pipeline.yaml
@@ -1,0 +1,78 @@
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: provision-osd-gcp
+spec:
+  description: Provision OSD on GCP
+  params:
+    - default: kua-gcp-credentials
+      description: Name of secret that contains JSON credentials for GCP (osd-ccs-admin user)
+      name: gcp-credentials
+      type: string
+    - default: kua-ocm-stage-client-credentials
+      description: Name of secret that contains client ID and client secret to log into OCM org
+      name: ocm-credentials
+      type: string
+    - default: staging
+      description: 'What OCM instance to use, either ''staging'' or ''production'''
+      name: ocm-instance
+      type: string
+    - default: kua-gcp-test
+      description: OSD cluster name
+      name: cluster-name
+      type: string
+    - default: '--provider=gcp --ccs --channel-group=stable --compute-machine-type=n2-standard-4 --compute-nodes=3 --enable-autoscaling=false --multi-az=false --region=us-east1 --version=4.17.12 --machine-cidr=10.0.0.0/16 --pod-cidr=10.128.0.0/14 --service-cidr=172.36.0.0/16 --host-prefix=23'
+      description: 'Flags to be used for `ocm create cluster [:osd-name]` command. Do not provide --service-account-file flag here.'
+      name: create-cmd-flags
+      type: string
+  tasks:
+    - name: ocm-login
+      params:
+        - name: ocm-instance
+          value: $(params.ocm-instance)
+        - name: ocm-credentials
+          value: $(params.ocm-credentials)
+      taskRef:
+        kind: Task
+        name: ocm-login
+      workspaces:
+        - name: shared-workspace
+    - name: provision-osd-gcp
+      params:
+        - name: gcp-credentials
+          value: $(params.gcp-credentials)
+        - name: create-cmd-flags
+          value: $(params.create-cmd-flags)
+        - name: cluster-name
+          value: $(params.cluster-name)
+      taskRef:
+        kind: Task
+        name: provision-osd-gcp
+      runAfter:
+        - ocm-login
+      workspaces:
+        - name: shared-workspace
+    - name: wait-till-osd-is-ready
+      params:
+        - name: cluster-id
+          value: $(tasks.provision-osd-gcp.results.cluster-id)
+      taskRef:
+        kind: Task
+        name: wait-till-osd-is-ready
+      runAfter:
+        - provision-osd-gcp
+      workspaces:
+        - name: shared-workspace
+    - name: get-osd-credentials
+      params:
+        - name: cluster-id
+          value: $(tasks.provision-osd-gcp.results.cluster-id)
+      taskRef:
+        kind: Task
+        name: get-osd-credentials
+      runAfter:
+        - wait-till-osd-is-ready
+      workspaces:
+        - name: shared-workspace
+  workspaces:
+    - name: shared-workspace

--- a/tasks/infra/delete-osd-task.yaml
+++ b/tasks/infra/delete-osd-task.yaml
@@ -1,0 +1,29 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: delete-osd
+spec:
+  description: 'Deletes OSD.'
+  params:
+    - name: cluster-id
+      description: cluster ID that OCM uses to identify the cluster
+  steps:
+    - computeResources:
+        limits:
+          cpu: '100m'
+          memory: 64Mi
+      image: 'quay.io/trepel/kuadrant-pipelines:latest'
+      imagePullPolicy: Always
+      name: delete-osd
+      script: |
+        #!/usr/bin/env bash
+        set -evo pipefail
+
+        # Use ocm.json created by ocm-login Task
+        export OCM_CONFIG=$(workspaces.shared-workspace.path)/ocm.json
+
+        # OSD Cluster Deletion Trigger
+        ocm delete cluster $(params.cluster-id)
+  workspaces:
+    - name: shared-workspace
+

--- a/tasks/infra/get-osd-credentials-task.yaml
+++ b/tasks/infra/get-osd-credentials-task.yaml
@@ -1,0 +1,57 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: get-osd-credentials
+spec:
+  description: 'Get OSD or ROSA cluster credentials'
+  params:
+    - name: cluster-id
+      type: string
+  results:
+    - name: password
+      description: kubeadmin password
+    - name: api-url
+      description: API URL of the cluster
+    - name: console-url
+      description: console URL of the cluster
+    - name: kubeadmin-console-url
+      description: console URL of the cluster for kubeadmin user
+    - name: login-command
+      description: full login command
+  steps:
+    - computeResources:
+        limits:
+          cpu: '100m'
+          memory: 64Mi
+      image: 'quay.io/trepel/kuadrant-pipelines:latest'
+      imagePullPolicy: Always
+      name: get-osd-credentials
+      script: |
+        #!/usr/bin/env bash
+        set -evo pipefail
+
+        # Use ocm.json created by ocm-login Task
+        export OCM_CONFIG=$(workspaces.shared-workspace.path)/ocm.json
+
+        # Get Cluster Information
+        password=$(ocm get /api/clusters_mgmt/v1/clusters/$(params.cluster-id)/credentials | jq -r '.admin.password')
+        api_url=$(ocm get /api/clusters_mgmt/v1/clusters/$(params.cluster-id) | jq -r '.api.url')
+        console_url=$(ocm get /api/clusters_mgmt/v1/clusters/$(params.cluster-id) | jq -r '.console.url')
+        login_cmd=$(echo "oc login $api_url -u kubeadmin -p $password")
+
+        cluster_login=$(ocm get /api/clusters_mgmt/v1/clusters/$(params.cluster-id) | jq -r '[.domain_prefix, .dns.base_domain] | join(".")')
+        kubeadmin_url="https://oauth-openshift.apps.$cluster_login/login?then=%2Foauth%2Fauthorize%3Fclient_id%3Dconsole%26redirect_uri%3Dhttps%253A%252F%252Fconsole-openshift-console.apps.$cluster_login%252Fauth%252Fcallback%26response_type%3Dcode%26scope%3Duser%253Afull"
+
+        # Return Cluster Information
+        echo -n $password | tee $(results.password.path) && echo ""
+
+        echo -n $api_url | tee $(results.api-url.path) && echo ""
+
+        echo -n $console_url | tee $(results.console-url.path) && echo ""
+
+        echo -n $login_cmd | tee $(results.login-command.path) && echo ""
+
+        echo -n $kubeadmin_url | tee $(results.kubeadmin-console-url.path)
+  workspaces:
+    - name: shared-workspace
+

--- a/tasks/infra/kustomization.yaml
+++ b/tasks/infra/kustomization.yaml
@@ -5,3 +5,6 @@ resources:
   - ocm-login-task.yaml
   - provision-osd-aws-task.yaml
   - wait-till-osd-is-ready-task.yaml
+  - get-osd-credentials-task.yaml
+  - delete-osd-task.yaml
+  - wait-till-osd-is-deleted-task.yaml

--- a/tasks/infra/kustomization.yaml
+++ b/tasks/infra/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ocm-login-task.yaml
+  - provision-osd-aws-task.yaml
+  - wait-till-osd-is-ready-task.yaml

--- a/tasks/infra/kustomization.yaml
+++ b/tasks/infra/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - get-osd-credentials-task.yaml
   - delete-osd-task.yaml
   - wait-till-osd-is-deleted-task.yaml
+  - provision-osd-gcp-task.yaml

--- a/tasks/infra/ocm-login-task.yaml
+++ b/tasks/infra/ocm-login-task.yaml
@@ -1,0 +1,40 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: ocm-login
+spec:
+  description: 'Logs into specified OCM instance'
+  params:
+    - name: ocm-credentials
+      type: string
+    - name: ocm-instance
+      type: string
+  steps:
+    - computeResources:
+        limits:
+          cpu: '100m'
+          memory: 64Mi
+      env:
+        - name: CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              key: CLIENT_ID
+              name: $(params.ocm-credentials)
+        - name: CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              key: CLIENT_SECRET
+              name: $(params.ocm-credentials)
+      image: 'quay.io/trepel/kuadrant-pipelines:latest'
+      imagePullPolicy: Always
+      name: ocm-login
+      script: |
+        #!/usr/bin/env bash
+        set -evo pipefail
+
+        export OCM_CONFIG=$(workspaces.shared-workspace.path)/ocm.json
+        ocm login --url $(params.ocm-instance) --client-id ${CLIENT_ID} --client-secret ${CLIENT_SECRET}
+        ocm whoami
+  workspaces:
+    - name: shared-workspace
+

--- a/tasks/infra/provision-osd-aws-task.yaml
+++ b/tasks/infra/provision-osd-aws-task.yaml
@@ -1,0 +1,55 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: provision-osd-aws
+spec:
+  description: 'Provisions OSD on AWS'
+  params:
+    - name: aws-credentials
+      type: string
+    - name: create-cmd-flags
+      type: string
+    - name: cluster-name
+      type: string
+  results:
+    - name: cluster-id
+      description: cluster ID that OCM uses to identify the cluster
+  steps:
+    - computeResources:
+        limits:
+          cpu: '100m'
+          memory: 64Mi
+      env:
+        - name: AWS_ACCOUNT_ID
+          valueFrom:
+            secretKeyRef:
+              key: AWS_ACCOUNT_ID
+              name: $(params.aws-credentials)
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              key: AWS_ACCESS_KEY_ID
+              name: $(params.aws-credentials)
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: AWS_SECRET_ACCESS_KEY
+              name: $(params.aws-credentials)
+      image: 'quay.io/trepel/kuadrant-pipelines:latest'
+      imagePullPolicy: Always
+      name: provision-osd-aws
+      script: |
+        #!/usr/bin/env bash
+        set -evo pipefail
+
+        # Use ocm.json created by ocm-login Task
+        export OCM_CONFIG=$(workspaces.shared-workspace.path)/ocm.json
+
+        # OSD Cluster Creation Trigger
+        ocm create cluster $(params.cluster-name) $(params.create-cmd-flags) --aws-access-key-id=${AWS_ACCESS_KEY_ID} --aws-secret-access-key=${AWS_SECRET_ACCESS_KEY} --aws-account-id=${AWS_ACCOUNT_ID}
+
+        # Include cluster ID in results
+        echo -n `ocm get /api/clusters_mgmt/v1/clusters --parameter search="name like '$(params.cluster-name)'" | jq -r '.items[0].id'` | tee $(results.cluster-id.path)
+  workspaces:
+    - name: shared-workspace
+

--- a/tasks/infra/provision-osd-gcp-task.yaml
+++ b/tasks/infra/provision-osd-gcp-task.yaml
@@ -1,0 +1,51 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: provision-osd-gcp
+spec:
+  description: 'Provisions OSD on GCP'
+  params:
+    - name: gcp-credentials
+      type: string
+    - name: create-cmd-flags
+      type: string
+    - name: cluster-name
+      type: string
+  results:
+    - name: cluster-id
+      description: cluster ID that OCM uses to identify the cluster
+  steps:
+    - computeResources:
+        limits:
+          cpu: '100m'
+          memory: 64Mi
+      env:
+        - name: SERVICE_ACCOUNT_FILE
+          valueFrom:
+            secretKeyRef:
+              key: gcp-osd-ccs-admin-sa-security-key.json
+              name: $(params.gcp-credentials)
+      image: 'quay.io/trepel/kuadrant-pipelines:latest'
+      imagePullPolicy: Always
+      name: provision-osd-gcp
+      script: |
+        #!/usr/bin/env bash
+        set -evo pipefail
+
+        # Use ocm.json created by ocm-login Task
+        export OCM_CONFIG=$(workspaces.shared-workspace.path)/ocm.json
+
+        # Create GCP service account file
+        echo -n "${SERVICE_ACCOUNT_FILE}" > gcp-osd-ccs-admin-sa-security-key.json
+
+        # OSD Cluster Creation Trigger
+        ocm create cluster $(params.cluster-name) $(params.create-cmd-flags) --service-account-file=gcp-osd-ccs-admin-sa-security-key.json
+
+        # Explicit removal of the file since it contains sensitive info
+        rm gcp-osd-ccs-admin-sa-security-key.json
+
+        # Include cluster ID in results
+        echo -n `ocm get /api/clusters_mgmt/v1/clusters --parameter search="name like '$(params.cluster-name)'" | jq -r '.items[0].id'` | tee $(results.cluster-id.path)
+  workspaces:
+    - name: shared-workspace
+

--- a/tasks/infra/wait-till-osd-is-deleted-task.yaml
+++ b/tasks/infra/wait-till-osd-is-deleted-task.yaml
@@ -1,0 +1,44 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: wait-till-osd-is-deleted
+spec:
+  description: 'Wait till OSD is deleted'
+  params:
+    - name: cluster-id
+      type: string
+  steps:
+    - computeResources:
+        limits:
+          cpu: '100m'
+          memory: 64Mi
+      image: 'quay.io/trepel/kuadrant-pipelines:latest'
+      imagePullPolicy: Always
+      name: wait-till-osd-is-deleted
+      script: |
+        #!/usr/bin/env bash
+        set -evo pipefail
+
+        # Use ocm.json created by ocm-login Task
+        export OCM_CONFIG=$(workspaces.shared-workspace.path)/ocm.json
+
+        # Wait for cluster to become ready
+        INTERVAL=60  # Check every 60 seconds
+        MAX_ATTEMPTS=60
+        echo "Waiting for cluster $(params.cluster-id) to be deleted, active check each $INTERVAL seconds, max no. of checks is $MAX_ATTEMPTS"
+
+        for ((i=0; i<MAX_ATTEMPTS; i++)); do
+            output=$(ocm list clusters | grep $(params.cluster-id) || true)
+            if [[ -z "${output// /}" ]]; then
+                echo "Cluster has been deleted."
+                break
+            fi
+            echo "Waiting for cluster to be deleted..."
+            sleep $INTERVAL
+        done
+
+        echo "Either cluster $(params.cluster-id) is deleted now or max no. of checks has been reached"
+      timeout: 1h30m0s
+  workspaces:
+    - name: shared-workspace
+

--- a/tasks/infra/wait-till-osd-is-ready-task.yaml
+++ b/tasks/infra/wait-till-osd-is-ready-task.yaml
@@ -1,0 +1,45 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: wait-till-osd-is-ready
+spec:
+  description: 'Wait till OSD is ready'
+  params:
+    - name: cluster-id
+      type: string
+  steps:
+    - computeResources:
+        limits:
+          cpu: '100m'
+          memory: 64Mi
+      image: 'quay.io/trepel/kuadrant-pipelines:latest'
+      imagePullPolicy: Always
+      name: wait-till-osd-is-ready
+      script: |
+        #!/usr/bin/env bash
+        set -evo pipefail
+
+        # Use ocm.json created by ocm-login Task
+        export OCM_CONFIG=$(workspaces.shared-workspace.path)/ocm.json
+
+        # Wait for cluster to become ready
+        INTERVAL=60  # Check every 60 seconds
+        MAX_ATTEMPTS=60
+        echo "Waiting for cluster to become ready, active check each $INTERVAL seconds, max no. of checks is $MAX_ATTEMPTS"
+
+        for ((i=0; i<MAX_ATTEMPTS; i++)); do
+            STATE=$(ocm describe cluster $(params.cluster-id) | grep 'State' | awk '{print $2}')
+            echo "Current cluster state is $STATE"
+            if [ "$STATE" == "ready" ]; then
+                echo "Cluster is ready."
+                break
+            fi
+            echo "Waiting for cluster  $(params.cluster-id) to become ready..."
+            sleep $INTERVAL
+        done
+
+        echo "Either cluster is ready now or max no. of checks has been reached"
+      timeout: 1h30m0s
+  workspaces:
+    - name: shared-workspace
+


### PR DESCRIPTION
Adds pipeline for OSD on AWS cluster creation.

`oc apply -k infra/ -n desired-ns`

One has to have secrets created in desired namespace:

`kubectl create secret generic kua-ocm-stage-client-credentials --from-literal=CLIENT_ID="xxx" --from-literal=CLIENT_SECRET="xxx" -n desired-ns`

`kubectl create secret generic kua-aws-credentials --from-literal=AWS_ACCOUNT_ID="xxx" --from-literal=AWS_ACCESS_KEY_ID="xxx" --from-literal=AWS_SECRET_ACCESS_KEY="xxx" -n desired-ns`