### PR TITLE
Add more tools to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,16 @@
-FROM registry.redhat.io/ubi8/ubi-minimal:latest
+FROM quay.io/app-sre/ubi9-ubi-minimal:latest
 
-RUN curl -Lso ocm https://github.com/openshift-online/ocm-cli/releases/download/v1.0.3/ocm-linux-amd64 && chmod +x ocm && mv ocm /usr/local/bin && microdnf install jq
+RUN microdnf -y install jq tar git
+
+RUN curl -LSs -o /usr/local/bin/ocm "https://github.com/openshift-online/ocm-cli/releases/download/$(curl -Lfs https://api.github.com/repos/openshift-online/ocm-cli/releases/latest \
+    | jq -r .tag_name)/ocm-linux-amd64" \
+    && chmod 0755 /usr/local/bin/ocm
+RUN curl -Lfs "https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3" | bash  # installs to /usr/local/bin/helm
+RUN curl -LSs -o /usr/local/bin/kubectl "https://dl.k8s.io/release/$(curl -Lfs https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" \
+    && chmod 0755 /usr/local/bin/kubectl
+RUN curl -Lfs "https://github.com/openshift/rosa/releases/download/$(curl -Lfs https://api.github.com/repos/openshift/rosa/releases/latest \
+    | jq -r .tag_name)/rosa_Linux_x86_64.tar.gz" | \
+    tar -xz -f - -C /usr/local/bin 'rosa' \
+    && chmod 0755 /usr/local/bin/rosa
+
+CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM quay.io/app-sre/ubi9-ubi-minimal:latest
 
-RUN microdnf -y install jq tar git
+RUN microdnf -y install jq tar git buildah
 
 RUN curl -LSs -o /usr/local/bin/ocm "https://github.com/openshift-online/ocm-cli/releases/download/$(curl -Lfs https://api.github.com/repos/openshift-online/ocm-cli/releases/latest \
     | jq -r .tag_name)/ocm-linux-amd64" \
@@ -12,5 +12,8 @@ RUN curl -Lfs "https://github.com/openshift/rosa/releases/download/$(curl -Lfs h
     | jq -r .tag_name)/rosa_Linux_x86_64.tar.gz" | \
     tar -xz -f - -C /usr/local/bin 'rosa' \
     && chmod 0755 /usr/local/bin/rosa
+RUN curl -LSs -o /usr/local/bin/opm "https://github.com/operator-framework/operator-registry/releases/download/$(curl -Lfs https://api.github.com/repos/operator-framework/operator-registry/releases/latest \
+    | jq -r .tag_name)/linux-amd64-opm" \
+    && chmod 0755 /usr/local/bin/opm
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
The image built from this Dockerfile should replace all images used in this repository.
I changed the base image to one pulled from public repository for easier building on non-authenticated machines.
Added more tools used in other pipelines:

- helm
- rosa
- kubectl
- opm (for upcoming downstream deploy pipeline)
- buildah (for upcoming downstream deploy pipeline)


I checked the image size difference with this version and version with all commands merged into single `RUN` statement and it was identical so I kept this multiple `RUN` version for better readability.

When building the image I suggest using `--no-cache` flag to make sure the newest version of the tools is installed.