### PR TITLE
Pipeline to provision ROSA

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM quay.io/app-sre/ubi9-ubi-minimal:latest
 
-RUN microdnf -y install jq tar git buildah findutils
+RUN microdnf -y install jq tar git buildah findutils unzip
 
 RUN curl -LSs -o /usr/local/bin/ocm "https://github.com/openshift-online/ocm-cli/releases/download/$(curl -Lfs https://api.github.com/repos/openshift-online/ocm-cli/releases/latest \
     | jq -r .tag_name)/ocm-linux-amd64" \
@@ -15,5 +15,9 @@ RUN curl -Lfs "https://github.com/openshift/rosa/releases/download/$(curl -Lfs h
 RUN curl -LSs -o /usr/local/bin/opm "https://github.com/operator-framework/operator-registry/releases/download/$(curl -Lfs https://api.github.com/repos/operator-framework/operator-registry/releases/latest \
     | jq -r .tag_name)/linux-amd64-opm" \
     && chmod 0755 /usr/local/bin/opm
+RUN curl -LSs -o awscli.zip "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" \
+    && unzip awscli.zip \
+    && ./aws/install -i /usr/local/aws -b /usr/local/bin \
+    && rm -rf ./aws ./awscli.zip
 
 CMD ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ kubectl create secret generic kua-ocm-stage-client-credentials --from-literal=CL
 kubectl create secret generic kua-gcp-credentials --from-file=gcp-osd-ccs-admin-sa-security-key.json -n ${PIPELINE_NAMESPACE}
 ```
 
+- Opaque secret containing ROSA credentials for an IAM user (pipelines provisioning ROSA cluster only). E.g.
+```shell
+kubectl create secret generic kua-rosa-credentials --from-literal=AWS_ACCOUNT_ID="xxx" --from-literal=AWS_ACCESS_KEY_ID="xxx" --from-literal=AWS_SECRET_ACCESS_KEY="xxx" -n ${PIPELINE_NAMESPACE}
+```
+
 Pipeline execution
 ---
 1. Through the OpenShift Web Console
@@ -80,3 +85,14 @@ Setup automatic cleanup of old PipelineRun's every week
 ```shell
 kubectl patch tektonconfig config --type=merge -p '{"spec":{"pruner":{"disabled":false,"keep":7,"resources":["pipelinerun"],"schedule":"0 0 * * 0"}}}'
 ```
+
+Pipeline image
+---
+If `Dockerfile` has been modified:
+```shel
+podman build -t quay.io/kuadrant/testsuite-pipelines-tools:latest --no-cache .
+podman push quay.io/kuadrant/testsuite-pipelines-tools:latest
+```
+
+Only members of [QE Team](https://quay.io/organization/kuadrant/teams/qe) and `kuadrant+qe` robot account are allowed to do the push.
+

--- a/infra/delete-rosa-pipeline.yaml
+++ b/infra/delete-rosa-pipeline.yaml
@@ -1,0 +1,55 @@
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: delete-rosa
+spec:
+  description: Delete ROSA cluster
+  params:
+    - default: kua-rosa-credentials
+      description: Name of secret that contains IAM user credentials
+      name: aws-credentials
+      type: string
+    - default: kua-ocm-stage-client-credentials
+      description: Name of secret that contains client ID and client secret to log into OCM org
+      name: ocm-credentials
+      type: string
+    - default: staging
+      description: 'What OCM instance to use, either ''staging'' or ''production'''
+      name: ocm-instance
+      type: string
+    - description: ROSA cluster ID that is to be deleted
+      name: cluster-id
+      type: string
+  tasks:
+    - name: rosa-login
+      params:
+        - name: ocm-instance
+          value: $(params.ocm-instance)
+        - name: ocm-credentials
+          value: $(params.ocm-credentials)
+        - name: region
+          value: us-east-1 # region does not matter for ROSA cluster removal
+        - name: aws-credentials
+          value: $(params.aws-credentials)
+      taskRef:
+        kind: Task
+        name: rosa-login
+      workspaces:
+        - name: shared-workspace
+    - name: delete-rosa
+      params:
+        - name: cluster-id
+          value: $(params.cluster-id)
+        - name: aws-credentials
+          value: $(params.aws-credentials)
+        - name: region
+          value: us-east-1 # region does not matter for ROSA cluster removal
+      taskRef:
+        kind: Task
+        name: delete-rosa
+      runAfter:
+        - rosa-login
+      workspaces:
+        - name: shared-workspace
+  workspaces:
+    - name: shared-workspace

--- a/infra/kustomization.yaml
+++ b/infra/kustomization.yaml
@@ -9,3 +9,5 @@ resources:
   - osd-aws-pipeline.yaml
   - delete-osd-pipeline.yaml
   - osd-gcp-pipeline.yaml
+  - rosa-pipeline.yaml
+  - delete-rosa-pipeline.yaml

--- a/infra/rosa-pipeline.yaml
+++ b/infra/rosa-pipeline.yaml
@@ -1,0 +1,101 @@
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: provision-rosa
+spec:
+  description: Provision ROSA
+  params:
+    - default: kua-rosa-credentials
+      description: Name of secret that contains IAM user credentials
+      name: aws-credentials
+      type: string
+    - default: kua-ocm-stage-client-credentials
+      description: Name of secret that contains client ID and client secret to log into OCM org
+      name: ocm-credentials
+      type: string
+    - default: staging
+      description: 'What OCM instance to use, either ''staging'' or ''production'''
+      name: ocm-instance
+      type: string
+    - default: kua-rosa-test
+      description: OSD cluster name
+      name: cluster-name
+      type: string
+    - default: '--compute-machine-type m5.xlarge --replicas 3 --non-sts --use-local-credentials -y'
+      description: 'Flags to be used for `rosa create cluster [:cluster-name]` command. Do not provide --cluster-name and --region flags here.'
+      name: create-cmd-flags
+      type: string
+    - default: us-east-1
+      description: AWS Region to use
+      name: region
+      type: string
+  tasks:
+    - name: rosa-login
+      params:
+        - name: ocm-instance
+          value: $(params.ocm-instance)
+        - name: ocm-credentials
+          value: $(params.ocm-credentials)
+        - name: region
+          value: $(params.region)
+        - name: aws-credentials
+          value: $(params.aws-credentials)
+      taskRef:
+        kind: Task
+        name: rosa-login
+      workspaces:
+        - name: shared-workspace
+    - name: provision-rosa
+      params:
+        - name: aws-credentials
+          value: $(params.aws-credentials)
+        - name: create-cmd-flags
+          value: $(params.create-cmd-flags)
+        - name: cluster-name
+          value: $(params.cluster-name)
+        - name: region
+          value: $(params.region)
+      taskRef:
+        kind: Task
+        name: provision-rosa
+      runAfter:
+        - rosa-login
+      workspaces:
+        - name: shared-workspace
+    - name: wait-till-osd-is-ready
+      params:
+        - name: cluster-id
+          value: $(tasks.provision-rosa.results.cluster-id)
+      taskRef:
+        kind: Task
+        name: wait-till-osd-is-ready
+      runAfter:
+        - provision-rosa
+      workspaces:
+        - name: shared-workspace
+    - name: get-osd-credentials
+      params:
+        - name: cluster-id
+          value: $(tasks.provision-rosa.results.cluster-id)
+      taskRef:
+        kind: Task
+        name: get-osd-credentials
+      runAfter:
+        - wait-till-osd-is-ready
+      workspaces:
+        - name: shared-workspace
+    - name: wait-for-valid-certificates
+      params:
+        - name: console-url
+          value: $(tasks.get-osd-credentials.results.console-url)
+        - name: api-url
+          value: $(tasks.get-osd-credentials.results.api-url)
+      taskRef:
+        kind: Task
+        name: wait-for-valid-certificates
+      runAfter:
+        - get-osd-credentials
+      workspaces:
+        - name: shared-workspace
+  workspaces:
+    - name: shared-workspace

--- a/tasks/infra/delete-rosa-task.yaml
+++ b/tasks/infra/delete-rosa-task.yaml
@@ -1,0 +1,73 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: delete-rosa
+spec:
+  description: 'Deletes ROSA.'
+  params:
+    - name: cluster-id
+      type: string
+    - name: aws-credentials
+      type: string
+    - name: region
+      type: string
+  steps:
+    - computeResources:
+        limits:
+          cpu: '100m'
+          memory: 64Mi
+      env:
+        - name: AWS_ACCOUNT_ID
+          valueFrom:
+            secretKeyRef:
+              key: AWS_ACCOUNT_ID
+              name: $(params.aws-credentials)
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              key: AWS_ACCESS_KEY_ID
+              name: $(params.aws-credentials)
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: AWS_SECRET_ACCESS_KEY
+              name: $(params.aws-credentials)
+      image: 'quay.io/kuadrant/testsuite-pipelines-tools:latest'
+      imagePullPolicy: Always
+      name: delete-rosa
+      script: |
+        #!/usr/bin/env bash
+        set -evo pipefail
+
+        # Use ocm.json created by rosa-login Task
+        export OCM_CONFIG=$(workspaces.shared-workspace.path)/ocm.json
+
+        # ROSA Cluster Deletion Trigger
+        rosa delete cluster --cluster=$(params.cluster-id) --region $(params.region) -y
+
+        # To output cluster uninstallation logs
+        rosa logs uninstall -c $(params.cluster-id) --region $(params.region) --watch
+
+        # Double check the cluster removal, it might take some time to complete after log stream finishes
+        INTERVAL=60  # Check every 60 seconds
+        MAX_ATTEMPTS=30
+        echo "Waiting for cluster $(params.cluster-id) to be deleted, active check each $INTERVAL seconds, max no. of checks is $MAX_ATTEMPTS"
+
+        for ((i=0; i<MAX_ATTEMPTS; i++)); do
+            output=$(ocm list clusters | grep $(params.cluster-id) || true)
+            if [[ -z "${output// /}" ]]; then
+                echo "Cluster has been deleted."
+                break
+            fi
+            echo "Waiting for cluster to be deleted..."
+            sleep $INTERVAL
+        done
+
+        # Additional removals not covered by cluster uninstallation
+        rosa delete operator-roles -c $(params.cluster-id) --region $(params.region) --mode auto -y || true
+        rosa delete oidc-provider -c $(params.cluster-id) --region $(params.region) --mode auto -y || true
+        rosa delete account-roles --prefix ManagedOpenShift --region $(params.region) --mode auto || true
+
+  workspaces:
+    - name: shared-workspace
+

--- a/tasks/infra/kustomization.yaml
+++ b/tasks/infra/kustomization.yaml
@@ -10,3 +10,7 @@ resources:
   - wait-till-osd-is-deleted-task.yaml
   - provision-osd-gcp-task.yaml
   - wait-for-valid-certificates-task.yaml
+  - rosa-login-task.yaml
+  - provision-rosa-task.yaml
+  - delete-rosa-task.yaml
+

--- a/tasks/infra/provision-rosa-task.yaml
+++ b/tasks/infra/provision-rosa-task.yaml
@@ -1,0 +1,57 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: provision-rosa
+spec:
+  description: 'Provisions ROSA'
+  params:
+    - name: aws-credentials
+      type: string
+    - name: create-cmd-flags
+      type: string
+    - name: cluster-name
+      type: string
+    - name: region
+      type: string
+  results:
+    - name: cluster-id
+      description: cluster ID that OCM uses to identify the cluster
+  steps:
+    - computeResources:
+        limits:
+          cpu: '100m'
+          memory: 64Mi
+      env:
+        - name: AWS_ACCOUNT_ID
+          valueFrom:
+            secretKeyRef:
+              key: AWS_ACCOUNT_ID
+              name: $(params.aws-credentials)
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              key: AWS_ACCESS_KEY_ID
+              name: $(params.aws-credentials)
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: AWS_SECRET_ACCESS_KEY
+              name: $(params.aws-credentials)
+      image: 'quay.io/kuadrant/testsuite-pipelines-tools:latest'
+      imagePullPolicy: Always
+      name: provision-rosa
+      script: |
+        #!/usr/bin/env bash
+        set -evo pipefail
+
+        # Use ocm.json created by ocm-login Task
+        export OCM_CONFIG=$(workspaces.shared-workspace.path)/ocm.json
+
+        # OSD Cluster Creation Trigger
+        rosa create cluster --cluster-name $(params.cluster-name) --region $(params.region) $(params.create-cmd-flags)
+
+        # Include cluster ID in results
+        echo -n `ocm get /api/clusters_mgmt/v1/clusters --parameter search="name like '$(params.cluster-name)'" | jq -r '.items[0].id'` | tee $(results.cluster-id.path)
+  workspaces:
+    - name: shared-workspace
+

--- a/tasks/infra/rosa-login-task.yaml
+++ b/tasks/infra/rosa-login-task.yaml
@@ -1,0 +1,59 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: rosa-login
+spec:
+  description: 'Logs into specified OCM instance via rosa cli'
+  params:
+    - name: ocm-credentials
+      type: string
+    - name: ocm-instance
+      type: string
+    - name: aws-credentials
+      type: string
+    - name: region
+      type: string
+  steps:
+    - computeResources:
+        limits:
+          cpu: '100m'
+          memory: 64Mi
+      env:
+        - name: CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              key: CLIENT_ID
+              name: $(params.ocm-credentials)
+        - name: CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              key: CLIENT_SECRET
+              name: $(params.ocm-credentials)
+        - name: AWS_ACCOUNT_ID
+          valueFrom:
+            secretKeyRef:
+              key: AWS_ACCOUNT_ID
+              name: $(params.aws-credentials)
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              key: AWS_ACCESS_KEY_ID
+              name: $(params.aws-credentials)
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: AWS_SECRET_ACCESS_KEY
+              name: $(params.aws-credentials)
+      image: 'quay.io/kuadrant/testsuite-pipelines-tools:latest'
+      imagePullPolicy: Always
+      name: rosa-login
+      script: |
+        #!/usr/bin/env bash
+        set -evo pipefail
+
+        export OCM_CONFIG=$(workspaces.shared-workspace.path)/ocm.json
+        rosa login --url $(params.ocm-instance) --client-id ${CLIENT_ID} --client-secret ${CLIENT_SECRET} --region $(params.region)
+        rosa whoami --region $(params.region)
+  workspaces:
+    - name: shared-workspace
+

--- a/tasks/infra/wait-till-osd-is-deleted-task.yaml
+++ b/tasks/infra/wait-till-osd-is-deleted-task.yaml
@@ -22,7 +22,7 @@ spec:
         # Use ocm.json created by ocm-login Task
         export OCM_CONFIG=$(workspaces.shared-workspace.path)/ocm.json
 
-        # Wait for cluster to become ready
+        # Wait for cluster to be deleted
         INTERVAL=60  # Check every 60 seconds
         MAX_ATTEMPTS=60
         echo "Waiting for cluster $(params.cluster-id) to be deleted, active check each $INTERVAL seconds, max no. of checks is $MAX_ATTEMPTS"


### PR DESCRIPTION
## Overview

This PR adds a pipeline to provision ROSA cluster.
- updates Dockerfile to add aws v2 cli tool, it is required by rosa cli tool
- readme update, just adding a AWS secret and some info about image building
- adds two tasks (rosa login and rosa provisioning)
- the image is already updated in quay.io

The wait for ready task and get credential tasks were reused.

## Verification Steps
Eye review together with eye check of the pipeline in `trepel` ns in kua multi 1 should suffice.