### PR TITLE
Allow for specifying cluster credentials via input parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Deployment
 Secrets
 ---
 Prior to the running of the pipeline, the following resources must be created in the pipeline namespace:
-- Opaque Secret named `openshift-pipelines-credentials` containing `KUBE_PASSWORD` and `KUBE_USER` keys 
+- Opaque Secret (pipelines expect `openshift-pipelines-credentials` name by default but custom name can be specified via `cluster-credentials` input parameter) containing `KUBE_PASSWORD` and `KUBE_USER` keys 
 with the credentials to access the testing cluster. E.g.
 ```shell
 kubectl create secret generic openshift-pipelines-credentials --from-literal=KUBE_USER="admin" --from-literal=KUBE_PASSWORD="admin" -n ${PIPELINE_NAMESPACE}

--- a/deploy/pipeline-nightly-update.yaml
+++ b/deploy/pipeline-nightly-update.yaml
@@ -7,6 +7,10 @@ spec:
   - description: API URL of the Openshift cluster
     name: kube-api
     type: string
+  - description: Secret name with cluster credentials
+    name: cluster-credentials
+    type: string
+    default: openshift-pipelines-credentials
   - description: Istio deployment. Only these values 'sail', 'ossm', 'ossm3'
     name: istio-provider
     type: string
@@ -42,6 +46,8 @@ spec:
       value: $(params.kube-api)
     - name: testsuite-image
       value: quay.io/kuadrant/testsuite-pipelines-tools:latest
+    - name: cluster-credentials
+      value: $(params.cluster-credentials)
     taskRef:
       kind: Task
       name: kubectl-login

--- a/deploy/pipeline.yaml
+++ b/deploy/pipeline.yaml
@@ -7,6 +7,10 @@ spec:
   - description: API URL of the Openshift cluster
     name: kube-api
     type: string
+  - description: Secret name with cluster credentials
+    name: cluster-credentials
+    type: string
+    default: openshift-pipelines-credentials
   - description: Kuadrant image url
     name: index-image
     type: string
@@ -44,6 +48,8 @@ spec:
       value: $(params.kube-api)
     - name: testsuite-image
       value: quay.io/kuadrant/testsuite-pipelines-tools:latest
+    - name: cluster-credentials
+      value: $(params.cluster-credentials)
     taskRef:
       kind: Task
       name: kubectl-login

--- a/main/pipeline.yaml
+++ b/main/pipeline.yaml
@@ -11,6 +11,10 @@ spec:
     - description: API URL of the Openshift cluster
       name: kube-api
       type: string
+    - description: Secret name with cluster credentials
+      name: cluster-credentials
+      type: string
+      default: openshift-pipelines-credentials
     - default: kuadrant
       description: Name of the Openshift project
       name: project
@@ -50,6 +54,8 @@ spec:
           value: $(params.testsuite-image)
         - name: kube-api
           value: $(params.kube-api)
+        - name: cluster-credentials
+          value: $(params.cluster-credentials)
       taskRef:
         kind: Task
         name: kubectl-login
@@ -71,6 +77,8 @@ spec:
           value: $(params.additional-env)
         - name: kubeconfig-path
           value: $(tasks.kubectl-login.results.kubeconfig-path)
+        - name: cluster-credentials
+          value: $(params.cluster-credentials)
       runAfter:
         - kubectl-login
       taskRef:

--- a/nightly/pipeline.yaml
+++ b/nightly/pipeline.yaml
@@ -11,6 +11,10 @@ spec:
     - description: API URL of the Openshift cluster
       name: kube-api
       type: string
+    - description: Secret name with cluster credentials
+      name: cluster-credentials
+      type: string
+      default: openshift-pipelines-credentials
     - default: kuadrant
       description: Name of the Openshift project
       name: project
@@ -53,6 +57,8 @@ spec:
           value: $(params.testsuite-image)
         - name: kube-api
           value: $(params.kube-api)
+        - name: cluster-credentials
+          value: $(params.cluster-credentials)
       taskRef:
         kind: Task
         name: kubectl-login
@@ -74,6 +80,8 @@ spec:
           value: $(params.additional-env)
         - name: kubeconfig-path
           value: $(tasks.kubectl-login.results.kubeconfig-path)
+        - name: cluster-credentials
+          value: $(params.cluster-credentials)
       runAfter:
         - kubectl-login
       taskRef:
@@ -87,6 +95,8 @@ spec:
           value: $(params.testsuite-image)
         - name: kube-api
           value: $(params.kube-api-second)
+        - name: cluster-credentials
+          value: $(params.cluster-credentials)
       taskRef:
         kind: Task
         name: kubectl-login
@@ -108,6 +118,8 @@ spec:
           value: $(params.additional-env)
         - name: kubeconfig-path
           value: $(tasks.kubectl-login-second-cluster.results.kubeconfig-path)
+        - name: cluster-credentials
+          value: $(params.cluster-credentials)
       runAfter:
         - kubectl-login-second-cluster
       taskRef:
@@ -131,6 +143,8 @@ spec:
           value: '$(params.additional-env) KUADRANT_CONTROL_PLANE__cluster2__kubeconfig_path=$(tasks.kubectl-login-second-cluster.results.kubeconfig-path)'
         - name: kubeconfig-path
           value: $(tasks.kubectl-login.results.kubeconfig-path)
+        - name: cluster-credentials
+          value: $(params.cluster-credentials)
       runAfter:
         - run-tests-kuadrant
         - run-tests-authorino-standalone
@@ -155,6 +169,8 @@ spec:
           value: "$(params.additional-env) KUADRANT_CONTROL_PLANE__provider_secret=gcp-credentials"
         - name: kubeconfig-path
           value: $(tasks.kubectl-login.results.kubeconfig-path)
+        - name: cluster-credentials
+          value: $(params.cluster-credentials)
       runAfter:
         - run-tests-multicluster
       taskRef:
@@ -178,6 +194,8 @@ spec:
           value: "$(params.additional-env) KUADRANT_CONTROL_PLANE__provider_secret=azure-credentials"
         - name: kubeconfig-path
           value: $(tasks.kubectl-login-second-cluster.results.kubeconfig-path)
+        - name: cluster-credentials
+          value: $(params.cluster-credentials)
       runAfter:
         - run-tests-multicluster
       taskRef:

--- a/tasks/login/kubectl-login-task.yaml
+++ b/tasks/login/kubectl-login-task.yaml
@@ -10,6 +10,9 @@ spec:
     - description: API URL of the Openshift cluster
       name: kube-api
       type: string
+    - description: Secret name with cluster credentials
+      name: cluster-credentials
+      type: string
   results:
     - name: kubeconfig-path
       description: Path to new kubeconfig in the workspace
@@ -40,12 +43,12 @@ spec:
           valueFrom:
             secretKeyRef:
               key: KUBE_USER
-              name: openshift-pipelines-credentials
+              name: $(params.cluster-credentials)
         - name: KUBE_PASSWORD
           valueFrom:
             secretKeyRef:
               key: KUBE_PASSWORD
-              name: openshift-pipelines-credentials
+              name: $(params.cluster-credentials)
       image: $(params.testsuite-image)
       imagePullPolicy: Always
       name: kubectl-login

--- a/tasks/run-tests-task.yaml
+++ b/tasks/run-tests-task.yaml
@@ -4,6 +4,9 @@ metadata:
   name: run-tests
 spec:
   params:
+    - description: Secret name with cluster credentials
+      name: cluster-credentials
+      type: string
     - description: Testsuite image to run tests on
       name: testsuite-image
       type: string
@@ -49,12 +52,12 @@ spec:
           valueFrom:
             secretKeyRef:
               key: KUBE_USER
-              name: openshift-pipelines-credentials
+              name: $(params.cluster-credentials)
         - name: KUBE_PASSWORD
           valueFrom:
             secretKeyRef:
               key: KUBE_PASSWORD
-              name: openshift-pipelines-credentials
+              name: $(params.cluster-credentials)
       image: $(params.testsuite-image)
       imagePullPolicy: Always
       name: run-tests


### PR DESCRIPTION
Allow for specifying cluster credentials via input parameter.
Default value is set for `openshift-pipelines-credentials` so pipelines should continue to work as they are, no need to explicitly set the input param.

## Verification Steps
Eye review. I validated via https://console-openshift-console.apps.kua-multi-1.osp.api-qe.eng.rdu2.redhat.com/k8s/ns/trepel/tekton.dev~v1~PipelineRun/kuadrant-deploy-pipeline-1c84as/parameters where I used custom secret name to install Kuadrant via helm.