### PR TITLE
Add xargs to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM quay.io/app-sre/ubi9-ubi-minimal:latest
 
-RUN microdnf -y install jq tar git buildah
+RUN microdnf -y install jq tar git buildah findutils
 
 RUN curl -LSs -o /usr/local/bin/ocm "https://github.com/openshift-online/ocm-cli/releases/download/$(curl -Lfs https://api.github.com/repos/openshift-online/ocm-cli/releases/latest \
     | jq -r .tag_name)/ocm-linux-amd64" \


### PR DESCRIPTION
Add missing utility used in helm-uninstall-task

`xargs` in contained in [findutils](https://www.gnu.org/software/findutils/)

I already pushed the new Dockerfile to tag `latest` and `0.2` in [quay.io/kuadrant/testsuite-pipelines-tools](https://quay.io/repository/kuadrant/testsuite-pipelines-tools?tab=tags)