### PR TITLE
Add ocp version and description to RP import task

### DIFF
--- a/main/pipeline.yaml
+++ b/main/pipeline.yaml
@@ -39,6 +39,10 @@ spec:
       description: Prefix of the launch name saved in report portal (nightly, username, manual, etc.)
       name: launch-name
       type: string
+    - default: ""
+      description: Optional launch description for Report Portal
+      name: launch-description
+      type: string
     - default: testsuite
       description: Report Portal Project to store test results (e.g. testsuite, nightly-testsuite)
       name: rp-project
@@ -95,12 +99,16 @@ spec:
       params:
         - name: launch-name
           value: $(params.launch-name)
+        - name: launch-description
+          value: $(params.launch-description)
         - name: testsuite-image
           value: $(params.testsuite-image)
         - name: make-target
           value: $(params.make-target)
         - name: rp-project
           value: $(params.rp-project)
+        - name: ocp-version
+          value: $(tasks.kubectl-login.results.ocp-version)
       taskRef:
         kind: Task
         name: upload-results

--- a/nightly/pipeline.yaml
+++ b/nightly/pipeline.yaml
@@ -42,6 +42,10 @@ spec:
       description: Prefix of the launch name saved in report portal (nightly, username, manual, etc.)
       name: launch-name
       type: string
+    - default: ""
+      description: Optional launch description for Report Portal
+      name: launch-description
+      type: string
     - default: nightly-testsuite
       description: Report Portal Project to store test results (e.g. testsuite, nightly-testsuite)
       name: rp-project
@@ -212,12 +216,16 @@ spec:
       params:
         - name: launch-name
           value: $(params.launch-name)
+        - name: launch-description
+          value: $(params.launch-description)
         - name: testsuite-image
           value: $(params.testsuite-image)
         - name: make-target
           value: all
         - name: rp-project
           value: $(params.rp-project)
+        - name: ocp-version
+          value: $(tasks.kubectl-login.results.ocp-version)
       taskRef:
         kind: Task
         name: upload-results

--- a/tasks/login/kubectl-login-task.yaml
+++ b/tasks/login/kubectl-login-task.yaml
@@ -16,6 +16,8 @@ spec:
   results:
     - name: kubeconfig-path
       description: Path to new kubeconfig in the workspace
+    - name: ocp-version
+      description: OCP cluster version
   steps:
     - args:
         - >-
@@ -27,7 +29,9 @@ spec:
           kubectl config set-credentials user --token=${TOKEN} &&
           kubectl config set-context ctx --user=user --cluster=ctx &&
           kubectl config use-context ctx &&
-          echo -n ${KUBECONFIG} | tee $(results.kubeconfig-path.path)
+          echo -n ${KUBECONFIG} | tee $(results.kubeconfig-path.path) &&
+          export OCP_VERSION=$(kubectl get clusterversion -o jsonpath='{.items[].status.history[0].version}') &&
+          echo -n ${OCP_VERSION%.*} | tee $(results.ocp-version.path)
       command:
         - /bin/bash
         - -cveo

--- a/tasks/upload-results-task.yaml
+++ b/tasks/upload-results-task.yaml
@@ -7,6 +7,9 @@ spec:
     - description: Prefix of the launch name saved in report portal (nightly, username, manual, etc.)
       name: launch-name
       type: string
+    - description: Launch description for Report Portal
+      name: launch-description
+      type: string
     - description: Testsuite image to run tests on
       name: testsuite-image
       type: string
@@ -15,6 +18,9 @@ spec:
       type: string
     - description: Report Portal Project to store test results
       name: rp-project
+      type: string
+    - description: OCP cluster version
+      name: ocp-version
       type: string
   steps:
     - args:
@@ -46,6 +52,10 @@ spec:
               name: rp-credentials
         - name: REQUESTS_CA_BUNDLE
           value: /var/ca-bundle/tls-ca-bundle.pem
+        - name: RP_LAUNCH_DESC
+          value: $(params.launch-description)
+        - name: OCP_VERSION
+          value: $(params.ocp-version)
       image: $(params.testsuite-image)
       imagePullPolicy: Always
       name: upload-results


### PR DESCRIPTION
Add testing cluster version label to imported launch. 

Required testsuite changes were in https://github.com/Kuadrant/testsuite/pull/646