### PR TITLE
Wait for valid certificates to be applied on OSD cluster

### DIFF
--- a/infra/osd-aws-pipeline.yaml
+++ b/infra/osd-aws-pipeline.yaml
@@ -74,5 +74,18 @@ spec:
         - wait-till-osd-is-ready
       workspaces:
         - name: shared-workspace
+    - name: wait-for-valid-certificates
+      params:
+        - name: console-url
+          value: $(tasks.get-osd-credentials.results.console-url)
+        - name: api-url
+          value: $(tasks.get-osd-credentials.results.api-url)
+      taskRef:
+        kind: Task
+        name: wait-for-valid-certificates
+      runAfter:
+        - get-osd-credentials
+      workspaces:
+        - name: shared-workspace
   workspaces:
     - name: shared-workspace

--- a/infra/osd-gcp-pipeline.yaml
+++ b/infra/osd-gcp-pipeline.yaml
@@ -74,5 +74,18 @@ spec:
         - wait-till-osd-is-ready
       workspaces:
         - name: shared-workspace
+    - name: wait-for-valid-certificates
+      params:
+        - name: console-url
+          value: $(tasks.get-osd-credentials.results.console-url)
+        - name: api-url
+          value: $(tasks.get-osd-credentials.results.api-url)
+      taskRef:
+        kind: Task
+        name: wait-for-valid-certificates
+      runAfter:
+        - get-osd-credentials
+      workspaces:
+        - name: shared-workspace
   workspaces:
     - name: shared-workspace

--- a/tasks/infra/kustomization.yaml
+++ b/tasks/infra/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - delete-osd-task.yaml
   - wait-till-osd-is-deleted-task.yaml
   - provision-osd-gcp-task.yaml
+  - wait-for-valid-certificates-task.yaml

--- a/tasks/infra/wait-for-valid-certificates-task.yaml
+++ b/tasks/infra/wait-for-valid-certificates-task.yaml
@@ -1,0 +1,55 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: wait-for-valid-certificates
+spec:
+  description: 'Wait till console and API URLs get valid certificates'
+  params:
+    - name: console-url
+      type: string
+    - name: api-url
+      type: string
+  steps:
+    - computeResources:
+        limits:
+          cpu: '100m'
+          memory: 64Mi
+      image: quay.io/kuadrant/testsuite-pipelines-tools:latest
+      imagePullPolicy: Always
+      name: wait-for-valid-certificates
+      script: |
+        #!/usr/bin/env bash
+        set -ev -o pipefail
+
+        # Wait for cluster to get valid certificates
+        INTERVAL=60  # Check every 60 seconds
+        MAX_ATTEMPTS=60
+        attempts=0 # no. of active checks already done
+        echo "Waiting for cluster to get valid certificates, active check each $INTERVAL seconds, max no. of checks is $MAX_ATTEMPTS"
+
+        for ((i=0; i<MAX_ATTEMPTS; i++)); do
+            attempts+=1
+            OUTPUT=$(curl -s -o /dev/null -w "%{http_code}\n" $(params.api-url) || true)
+            # Not authenticated so 403 Forbidden is expected once valid certificates are applied
+            if [[ "$OUTPUT" == "403" ]]; then
+                echo "API URL got valid certificate."
+                break
+            fi
+            echo "Waiting for API URL to get valid certificates..."
+            sleep $INTERVAL
+        done
+
+        for ((i=0; i<(MAX_ATTEMPTS-attempts); i++)); do
+            OUTPUT=$(curl -s -o /dev/null -w "%{http_code}\n" $(params.console-url) || true)
+            if [[ "$OUTPUT" == "200" ]]; then
+                echo "Console URL got valid certificate."
+                break
+            fi
+            echo "Waiting for Console URL to get valid certificates..."
+            sleep $INTERVAL
+        done
+
+        echo "Either cluster got valid certificates or max no. of checks has been reached"
+  workspaces:
+    - name: shared-workspace
+


### PR DESCRIPTION
## Overview

OCM/HCC says 'ready' once cluster is ready but it does only mean that all the operators are up and running. It does not necessarily mean that all of the operators have actually finished their jobs.

Waiting for valid certificates to get applied is a good way for checking the cluster readiness because it usually takes the most time.

Closes https://github.com/Kuadrant/testsuite-pipelines/issues/75

## Verification Steps

Eye review. You can also check the PipelineRun CR in `trepel` ns in kua multi 1 cluster where I tested this.