### PR TITLE
Added all-in-one pipeline

### DIFF
--- a/main/kustomization.yaml
+++ b/main/kustomization.yaml
@@ -6,4 +6,8 @@ commonLabels:
 
 resources:
   - ../tasks/
+  - ../tasks/deploy/
+  - ../tasks/infra/
+  - ../tasks/provision-install-test/
   - pipeline.yaml
+  - provision-install-test-pipeline.yaml

--- a/main/pipeline.yaml
+++ b/main/pipeline.yaml
@@ -36,7 +36,7 @@ spec:
       name: additional-env
       type: string
     - default: pipeline
-      description: Prefix of the launch name saved in report portal (nightly, username, manual, etc.)
+      description: Prefix of the launch name saved in report portal (nightly, username, manual, etc.). In case of release candidate testing use kuadrant-v<version>, rhcl-v<version>, or authorino-v<version>
       name: launch-name
       type: string
     - default: ""

--- a/main/provision-install-test-pipeline.yaml
+++ b/main/provision-install-test-pipeline.yaml
@@ -1,0 +1,480 @@
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: provision-install-test-pipeline
+spec:
+  params:
+# Cluster related parameters
+    - default: osd-aws
+      description: Cluster type (osd-aws, osd-gcp, rosa)
+      name: cluster-type
+      type: string
+    - default: ' '
+      description: Cloud Provider credentials, leave empty to use defaults
+      name: provider-credentials
+      type: string
+    - default: 'us-east-1'
+      description: AWS Region to use - required for rosa only
+      name: region
+      type: string
+    - default: staging
+      description: OCM/HCC instance (staging, production)
+      name: ocm-instance
+      type: string
+    - default: kua-ocm-stage-client-credentials
+      description: OCM/HCC credentials
+      name: ocm-credentials
+      type: string
+    - default: kua-test
+      description: Cluster name
+      name: cluster-name
+      type: string
+    - default: ' '
+      description: Cluster creation flags. Leave empty to use defaults (they depend on Cloud Provider)
+      name: create-cmd-flags
+      type: string
+# Kuadrant/RHCL installation related parameters
+    - default: quay.io/kuadrant/kuadrant-operator-catalog:v1.2.0
+      description: Kuadrant/RHCL index image, leave empty to install current RHCL GA
+      name: index-image
+      type: string
+    - default: stable
+      description: Kuadrant channel (stable, preview)
+      name: channel
+      type: string
+    - default: kuadrant-operator
+      description: Operator name (kuadrant-operator, rhcl-operator)
+      name: operator-name
+      type: string
+    - default: ocp
+      description: Istio provider (ossm3, ocp), use ossm3 for OCP v4.18 and before
+      name: istio-provider
+      type: string
+    - default: ' '
+      description: GatewayAPI CRD version. v1.0.0, v1.1.0, v1.2.1, v1.3.0 available; Leave empty if installing on OCP v4.19+
+      name: gateway-crd
+      type: string
+    - default: stable-v26
+      description: Keycloak subscription channel
+      name: keycloak-channel
+      type: string
+    - default: ' '
+      description: Additional flags for helm install command, example '--set=kuadrant.installPlanApproval=Manual --set=kuadrant.startingCSV=kuadrant-operator.v1.2.0'"
+      name: helm-install-flags
+      type: string
+# Testsuite related parameters
+    - default: 'quay.io/kuadrant/testsuite:unstable'
+      description: Testsuite image
+      name: testsuite-image
+      type: string
+    - default: kuadrant
+      description: Openshift project
+      name: project
+      type: string
+    - default: test
+      description: Makefile target for tests
+      name: make-target
+      type: string
+    - default: ' '
+      description: Pytest flags to use with Make (flags="${pytest-flags}" make kuadrant)
+      name: pytest-flags
+      type: string
+    - default: pipeline-settings
+      description: Config Map with settings for the testsuite
+      name: settings-cm
+      type: string
+    - default: ' '
+      description: Additional env for testsuite container separated with spaces (e.g. KUADRANT_CONTROL_PLANE__provider_secret=gcp-credentials KUADRANT_KEYCLOAK__url="https://my-sso.net")
+      name: additional-env
+      type: string
+# Report Portal related parameters
+    - default: pipeline
+      description: Prefix of the launch name saved in report portal (nightly, username, manual, etc.). In case of release candidate testing use kuadrant-v<version>, rhcl-v<version>, or authorino-v<version>
+      name: launch-name
+      type: string
+    - default: 'Pipeline'
+      description: Launch description for Report Portal
+      name: launch-description
+      type: string
+    - default: testsuite
+      description: Report Portal Project to store test results (testsuite or nightly-testsuite typically)
+      name: rp-project
+      type: string
+    - default: true
+      description: If set to 'true' upload test results to Report Portal
+      name: upload-results
+      type: string
+# Cleanup
+    - default: false
+      description: If set to 'true' cleanup will be done
+      name: cleanup
+      type: string
+  workspaces:
+    - name: shared-workspace
+  tasks:
+    - name: ocm-login
+      when:
+        - input: "$(params.cluster-type)"
+          operator: in
+          values: ['osd-aws', 'osd-gcp']
+      params:
+        - name: ocm-instance
+          value: $(params.ocm-instance)
+        - name: ocm-credentials
+          value: $(params.ocm-credentials)
+      taskRef:
+        kind: Task
+        name: ocm-login
+      workspaces:
+        - name: shared-workspace
+    - name: parameter-sanity-check
+      params:
+        - name: cluster-type
+          value: $(params.cluster-type)
+        - name: cluster-name
+          value: $(params.cluster-name)
+        - name: provider-credentials
+          value: $(params.provider-credentials)
+        - name: create-cmd-flags
+          value: $(params.create-cmd-flags)
+        - name: index-image
+          value: $(params.index-image)
+        - name: channel
+          value: $(params.channel)
+        - name: operator-name
+          value: $(params.operator-name)
+      runAfter:
+        - ocm-login
+      taskRef:
+        kind: Task
+        name: parameter-sanity-check
+      workspaces:
+        - name: shared-workspace
+    - name: rosa-login
+      when:
+        - input: "$(params.cluster-type)"
+          operator: in
+          values: ['rosa']
+      params:
+        - name: ocm-instance
+          value: $(params.ocm-instance)
+        - name: ocm-credentials
+          value: $(params.ocm-credentials)
+        - name: region
+          value: $(params.region)
+        - name: aws-credentials
+          value: $(tasks.parameter-sanity-check.results.provider-credentials)
+      runAfter:
+        - parameter-sanity-check
+      taskRef:
+        kind: Task
+        name: rosa-login
+      workspaces:
+        - name: shared-workspace
+    - name: provision-osd-aws
+      when:
+        - input: "$(params.cluster-type)"
+          operator: in
+          values: ['osd-aws']
+      params:
+        - name: aws-credentials
+          value: $(tasks.parameter-sanity-check.results.provider-credentials)
+        - name: create-cmd-flags
+          value: $(tasks.parameter-sanity-check.results.create-cmd-flags)
+        - name: cluster-name
+          value: $(params.cluster-name)
+      runAfter:
+        - parameter-sanity-check
+      taskRef:
+        kind: Task
+        name: provision-osd-aws
+      workspaces:
+        - name: shared-workspace
+    - name: provision-osd-gcp
+      when:
+        - input: "$(params.cluster-type)"
+          operator: in
+          values: ['osd-gcp']
+      params:
+        - name: gcp-credentials
+          value: $(tasks.parameter-sanity-check.results.provider-credentials)
+        - name: create-cmd-flags
+          value: $(tasks.parameter-sanity-check.results.create-cmd-flags)
+        - name: cluster-name
+          value: $(params.cluster-name)
+      runAfter:
+        - parameter-sanity-check
+      taskRef:
+        kind: Task
+        name: provision-osd-gcp
+      workspaces:
+        - name: shared-workspace
+    - name: provision-rosa
+      when:
+        - input: "$(params.cluster-type)"
+          operator: in
+          values: ['rosa']
+      params:
+        - name: aws-credentials
+          value: $(tasks.parameter-sanity-check.results.provider-credentials)
+        - name: create-cmd-flags
+          value: $(tasks.parameter-sanity-check.results.create-cmd-flags)
+        - name: cluster-name
+          value: $(params.cluster-name)
+        - name: region
+          value: $(params.region)
+      runAfter:
+        - rosa-login
+      taskRef:
+        kind: Task
+        name: provision-rosa
+      workspaces:
+        - name: shared-workspace
+    - name: get-cluster-id
+      params:
+        - name: cluster-name
+          value: $(params.cluster-name)
+      runAfter:
+        - provision-osd-aws
+        - provision-osd-gcp
+        - provision-rosa
+      taskRef:
+        kind: Task
+        name: get-cluster-id
+      workspaces:
+        - name: shared-workspace
+    - name: wait-till-osd-is-ready
+      params:
+        - name: cluster-id
+          value: $(tasks.get-cluster-id.results.cluster-id)
+      runAfter:
+        - get-cluster-id
+      taskRef:
+        kind: Task
+        name: wait-till-osd-is-ready
+      workspaces:
+        - name: shared-workspace
+    - name: get-osd-credentials
+      params:
+        - name: cluster-id
+          value: $(tasks.get-cluster-id.results.cluster-id)
+      runAfter:
+        - wait-till-osd-is-ready
+      taskRef:
+        kind: Task
+        name: get-osd-credentials
+      workspaces:
+        - name: shared-workspace
+    - name: wait-for-valid-certificates
+      params:
+        - name: console-url
+          value: $(tasks.get-osd-credentials.results.console-url)
+        - name: api-url
+          value: $(tasks.get-osd-credentials.results.kube-api)
+      taskRef:
+        kind: Task
+        name: wait-for-valid-certificates
+      runAfter:
+        - get-osd-credentials
+      workspaces:
+        - name: shared-workspace
+    - name: clone
+      runAfter:
+        - wait-for-valid-certificates
+      taskRef:
+        kind: Task
+        name: clone
+      workspaces:
+        - name: shared-workspace
+          workspace: shared-workspace
+    - name: check-image-existence
+      when:
+        - input: "$(params.index-image)"
+          operator: notin
+          values: ['']
+      params:
+        - name: index-image
+          value: $(params.index-image)
+      runAfter:
+        - wait-for-valid-certificates
+      taskRef:
+        kind: Task
+        name: check-image-existence
+    - name: kubectl-login
+      params:
+        - name: kube-api
+          value: $(tasks.get-osd-credentials.results.kube-api)
+        - name: testsuite-image
+          value: 'quay.io/kuadrant/testsuite-pipelines-tools:latest'
+        - name: cluster-credentials
+          value: $(tasks.get-osd-credentials.results.credentials-secret)
+      runAfter:
+        - wait-for-valid-certificates
+      taskRef:
+        kind: Task
+        name: kubectl-login
+      workspaces:
+        - name: shared-workspace
+          workspace: shared-workspace
+    - name: helm-uninstall
+      params:
+        - name: kubeconfig-path
+          value: $(tasks.kubectl-login.results.kubeconfig-path)
+      runAfter:
+        - clone
+        - kubectl-login
+        - check-image-existence
+      taskRef:
+        kind: Task
+        name: helm-uninstall
+      workspaces:
+        - name: shared-workspace
+          workspace: shared-workspace
+    - name: helm-install
+      params:
+        - name: index-image
+          value: $(params.index-image)
+        - name: channel
+          value: $(params.channel)
+        - name: istio-provider
+          value: $(params.istio-provider)
+        - name: operator-name
+          value: $(params.operator-name)
+        - name: kubeconfig-path
+          value: $(tasks.kubectl-login.results.kubeconfig-path)
+        - name: gateway-crd
+          value: $(params.gateway-crd)
+        - name: keycloak-channel
+          value: $(params.keycloak-channel)
+        - name: helm-install-flags
+          value: $(params.helm-install-flags)
+      runAfter:
+        - helm-uninstall
+      taskRef:
+        kind: Task
+        name: helm-install
+      workspaces:
+        - name: shared-workspace
+          workspace: shared-workspace
+    - name: run-tests
+      params:
+        - name: testsuite-image
+          value: $(params.testsuite-image)
+        - name: project
+          value: $(params.project)
+        - name: make-target
+          value: $(params.make-target)
+        - name: pytest-flags
+          value: $(params.pytest-flags)
+        - name: settings-cm
+          value: $(params.settings-cm)
+        - name: additional-env
+          value: $(params.additional-env)
+        - name: kubeconfig-path
+          value: $(tasks.kubectl-login.results.kubeconfig-path)
+        - name: cluster-credentials
+          value: $(tasks.get-osd-credentials.results.credentials-secret)
+      runAfter:
+        - helm-install
+      taskRef:
+        kind: Task
+        name: run-tests
+      workspaces:
+        - name: shared-workspace
+    - name: upload-results
+      when:
+        - input: $(params.upload-results)
+          operator: in
+          values: ["true"]
+      params:
+        - name: launch-name
+          value: $(params.launch-name)
+        - name: launch-description
+          value: $(params.launch-description)
+        - name: testsuite-image
+          value: $(params.testsuite-image)
+        - name: make-target
+          value: $(params.make-target)
+        - name: rp-project
+          value: $(params.rp-project)
+        - name: ocp-version
+          value: $(tasks.kubectl-login.results.ocp-version)
+      runAfter:
+        - run-tests
+      taskRef:
+        kind: Task
+        name: upload-results
+      workspaces:
+        - name: shared-workspace
+    - name: helm-uninstall-cleanup
+      when:
+        - input: $(params.cleanup)
+          operator: in
+          values: ["true"]
+      params:
+        - name: kubeconfig-path
+          value: $(tasks.kubectl-login.results.kubeconfig-path)
+      runAfter:
+        - upload-results
+        - run-tests
+      taskRef:
+        kind: Task
+        name: helm-uninstall
+      workspaces:
+        - name: shared-workspace
+          workspace: shared-workspace
+    - name: delete-osd
+      when:
+        - input: $(params.cleanup)
+          operator: in
+          values: ["true"]
+        - input: $(params.cluster-type)
+          operator: in
+          values: ["osd-aws", "osd-gcp"]
+      params:
+        - name: cluster-id
+          value: $(tasks.get-cluster-id.results.cluster-id)
+      runAfter:
+        - helm-uninstall-cleanup
+      taskRef:
+        kind: Task
+        name: delete-osd
+      workspaces:
+        - name: shared-workspace
+    - name: delete-rosa
+      when:
+        - input: $(params.cleanup)
+          operator: in
+          values: ["true"]
+        - input: $(params.cluster-type)
+          operator: in
+          values: ["rosa"]
+      params:
+        - name: cluster-id
+          value: $(tasks.get-cluster-id.results.cluster-id)
+        - name: region
+          value: $(params.region)
+        - name: aws-credentials
+          value: $(tasks.parameter-sanity-check.results.provider-credentials)
+      runAfter:
+        - helm-uninstall-cleanup
+      taskRef:
+        kind: Task
+        name: delete-rosa
+      workspaces:
+        - name: shared-workspace
+    - name: cluster-secret-cleanup
+      when:
+        - input: $(params.cleanup)
+          operator: in
+          values: ["true"]
+      params:
+        - name: cluster-name
+          value: $(params.cluster-name)
+      runAfter:
+        - helm-uninstall-cleanup
+      taskRef:
+        kind: Task
+        name: cluster-secret-cleanup
+      workspaces:
+        - name: shared-workspace

--- a/nightly/pipeline.yaml
+++ b/nightly/pipeline.yaml
@@ -39,7 +39,7 @@ spec:
       name: kube-api-second
       type: string
     - default: nightly
-      description: Prefix of the launch name saved in report portal (nightly, username, manual, etc.)
+      description: Prefix of the launch name saved in report portal (nightly, username, manual, etc.). In case of release candidate testing use kuadrant-v<version>, rhcl-v<version>, or authorino-v<version>
       name: launch-name
       type: string
     - default: ""

--- a/tasks/deploy/helm-install-task.yaml
+++ b/tasks/deploy/helm-install-task.yaml
@@ -13,7 +13,7 @@ spec:
     - description: A 'ossm3' for Openshift Service mesh v3, 'ocp' for installing on Openshift 4.19+
       name: istio-provider
       type: string
-    - description: GatewayAPI CRD version. Leave empty if installing on ocp4.19+
+    - description: GatewayAPI CRD version. v1.0.0, v1.1.0, v1.2.1, v1.3.0 available; Leave empty if installing on ocp4.19+
       name: gateway-crd
       type: string
     - description: Keycloak subscription channel

--- a/tasks/infra/get-osd-credentials-task.yaml
+++ b/tasks/infra/get-osd-credentials-task.yaml
@@ -10,7 +10,7 @@ spec:
   results:
     - name: password
       description: kubeadmin password
-    - name: api-url
+    - name: kube-api
       description: API URL of the cluster
     - name: console-url
       description: console URL of the cluster
@@ -18,11 +18,20 @@ spec:
       description: console URL of the cluster for kubeadmin user
     - name: login-command
       description: full login command
+    - name: credentials-secret
+      description: secret name with credentials
+    - name: cluster-id
+      description: Identifier assinged to cluster by OCM/HCC
   steps:
     - computeResources:
         limits:
           cpu: '100m'
           memory: 64Mi
+      env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
       image: quay.io/kuadrant/testsuite-pipelines-tools:latest
       imagePullPolicy: Always
       name: get-osd-credentials
@@ -38,6 +47,7 @@ spec:
         api_url=$(ocm get /api/clusters_mgmt/v1/clusters/$(params.cluster-id) | jq -r '.api.url')
         console_url=$(ocm get /api/clusters_mgmt/v1/clusters/$(params.cluster-id) | jq -r '.console.url')
         login_cmd=$(echo "oc login $api_url -u kubeadmin -p $password")
+        cluster_name=$(ocm get /api/clusters_mgmt/v1/clusters/$(params.cluster-id) | jq -r '.name')
 
         cluster_login=$(ocm get /api/clusters_mgmt/v1/clusters/$(params.cluster-id) | jq -r '[.domain_prefix, .dns.base_domain] | join(".")')
         kubeadmin_url="https://oauth-openshift.apps.$cluster_login/login?then=%2Foauth%2Fauthorize%3Fclient_id%3Dconsole%26redirect_uri%3Dhttps%253A%252F%252Fconsole-openshift-console.apps.$cluster_login%252Fauth%252Fcallback%26response_type%3Dcode%26scope%3Duser%253Afull"
@@ -45,13 +55,23 @@ spec:
         # Return Cluster Information
         echo -n $password | tee $(results.password.path) && echo ""
 
-        echo -n $api_url | tee $(results.api-url.path) && echo ""
+        echo -n $api_url | tee $(results.kube-api.path) && echo ""
 
         echo -n $console_url | tee $(results.console-url.path) && echo ""
 
         echo -n $login_cmd | tee $(results.login-command.path) && echo ""
 
         echo -n $kubeadmin_url | tee $(results.kubeadmin-console-url.path)
+
+        echo -n $(params.cluster-id) | tee $(results.cluster-id.path)
+
+        # Create secret with cluster credentials
+        echo -n "${cluster_name}-credentials" | tee $(results.credentials-secret.path)
+        kubectl create secret generic "${cluster_name}-credentials" --from-literal=KUBE_USER="kubeadmin" --from-literal=KUBE_PASSWORD="$password" -n ${NAMESPACE}
+
+        # Store api_url in shared workspace so that kubectl-login Task can access
+        # even without the need to pass it as parameter - this would be 'default' in such a case
+        echo "$api_url" > $(workspaces.shared-workspace.path)/kube-api.txt
   workspaces:
     - name: shared-workspace
 

--- a/tasks/provision-install-test/cluster-secret-cleanup-task.yaml
+++ b/tasks/provision-install-test/cluster-secret-cleanup-task.yaml
@@ -1,0 +1,30 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: cluster-secret-cleanup
+spec:
+  description: Remove the cluster credentials secret
+  params:
+    - name: cluster-name
+      type: string
+  steps:
+    - computeResources:
+        limits:
+          cpu: '100m'
+          memory: 64Mi
+      env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+      image: quay.io/kuadrant/testsuite-pipelines-tools:latest
+      imagePullPolicy: Always
+      name: cluster-cleanup
+      script: |
+        #!/usr/bin/env bash
+        set -evo pipefail
+
+        kubectl delete --ignore-not-found secret "$(params.cluster-name)-credentials" -n ${NAMESPACE}
+  workspaces:
+    - name: shared-workspace
+

--- a/tasks/provision-install-test/get-cluster-id-task.yaml
+++ b/tasks/provision-install-test/get-cluster-id-task.yaml
@@ -1,0 +1,32 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: get-cluster-id
+spec:
+  description: Retrieve OCM/HCC cluster ID
+  params:
+    - name: cluster-name
+      type: string
+  results:
+    - name: cluster-id
+      description: Cluster ID used in OCM/HCC
+  steps:
+    - computeResources:
+        limits:
+          cpu: '100m'
+          memory: 64Mi
+      image: quay.io/kuadrant/testsuite-pipelines-tools:latest
+      imagePullPolicy: Always
+      name: get-cluster-id
+      script: |
+        #!/usr/bin/env bash
+        set -evo pipefail
+
+        # Use ocm.json created by ocm-login Task
+        export OCM_CONFIG=$(workspaces.shared-workspace.path)/ocm.json
+
+        # Include cluster ID in results
+        echo -n `ocm get /api/clusters_mgmt/v1/clusters --parameter search="name like '$(params.cluster-name)'" | jq -r '.items[0].id'` | tee $(results.cluster-id.path)
+  workspaces:
+    - name: shared-workspace
+

--- a/tasks/provision-install-test/kustomization.yaml
+++ b/tasks/provision-install-test/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - get-cluster-id-task.yaml
+  - parameter-sanity-check-task.yaml
+  - cluster-secret-cleanup-task.yaml

--- a/tasks/provision-install-test/parameter-sanity-check-task.yaml
+++ b/tasks/provision-install-test/parameter-sanity-check-task.yaml
@@ -1,0 +1,95 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: parameter-sanity-check
+spec:
+  description: Sanitization of input parameters
+  params:
+    - name: cluster-type
+      type: string
+    - name: cluster-name
+      type: string
+    - name: provider-credentials
+      type: string
+    - name: create-cmd-flags
+      type: string
+    - name: index-image
+      type: string
+    - name: channel
+      type: string
+    - name: operator-name
+      type: string
+  results:
+    - name: provider-credentials
+      description: Credentials for cloud provider
+    - name: create-cmd-flags
+      description: Flags for cluster creation command
+  steps:
+    - computeResources:
+        limits:
+          cpu: '100m'
+          memory: 64Mi
+      env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+      image: quay.io/kuadrant/testsuite-pipelines-tools:latest
+      imagePullPolicy: Always
+      name: parameter-sanity-check
+      script: |
+        #!/usr/bin/env bash
+        set -evo pipefail
+
+        # Use ocm.json created by ocm-login Task
+        export OCM_CONFIG=$(workspaces.shared-workspace.path)/ocm.json
+
+        provider_creds="$(params.provider-credentials)"
+        cmd_flags="$(params.create-cmd-flags)"
+
+        # fail early if secret already exists
+        if kubectl get secret "$(params.cluster-name)-credentials" -n "$NAMESPACE" &>/dev/null; then
+          echo "Secret '$(params.cluster-name)-credentials' already exists in namespace '$NAMESPACE'. This indicates that a cluster with the same name already exists. Please use a different cluster name, or verify that no such cluster is present and remove the associated secret manually"
+          exit 1
+        fi
+
+        # make sure proper defaults are used if provider credentials are not specified
+        if [[ -z "${provider_creds//[[:space:]]/}" ]]; then
+          if [[ "$(params.cluster-type)" == "osd-aws" ]]; then
+            echo -n 'kua-aws-credentials' | tee $(results.provider-credentials.path) && echo ""
+          fi
+          if [[ "$(params.cluster-type)" == "osd-gcp" ]]; then
+            echo -n 'kua-gcp-credentials' | tee $(results.provider-credentials.path) && echo ""
+          fi
+          if [[ "$(params.cluster-type)" == "rosa" ]]; then
+            echo -n 'kua-rosa-credentials' | tee $(results.provider-credentials.path) && echo ""
+          fi
+        else
+          echo -n "$(params.provider-credentials)" | tee $(results.provider-credentials.path) && echo ""
+        fi
+
+        # determine what version to use if not specified
+        version=""
+        if [[ "$cmd_flags" != *"--version"* ]]; then
+          version=" --version=$(ocm list versions --default)"
+        fi
+
+        # make sure proper default flags are used for cluster creation command if these are not specified
+        if [[ -z "${cmd_flags//[[:space:]]/}" ]]; then
+          if [[ "$(params.cluster-type)" == "osd-aws" ]]; then
+            cmd_flags="${version} --provider=aws --ccs --channel-group=stable --compute-machine-type=m5.xlarge --compute-nodes=3 --enable-autoscaling=false --multi-az=false --region=us-east-1 --machine-cidr=10.11.128.0/23 --pod-cidr=10.11.64.0/18 --service-cidr=10.11.0.0/18 --host-prefix=23"
+          echo -n $cmd_flags | tee $(results.create-cmd-flags.path) && echo ""
+          fi
+          if [[ "$(params.cluster-type)" == "osd-gcp" ]]; then
+            cmd_flags="${version} --provider=gcp --ccs --channel-group=stable --compute-machine-type=n2-standard-4 --compute-nodes=3 --enable-autoscaling=false --multi-az=false --region=us-east1 --machine-cidr=10.0.0.0/16 --pod-cidr=10.128.0.0/14 --service-cidr=172.36.0.0/16 --host-prefix=23"
+          echo -n $cmd_flags | tee $(results.create-cmd-flags.path) && echo ""
+          fi
+          if [[ "$(params.cluster-type)" == "rosa" ]]; then
+            cmd_flags="${version} --compute-machine-type m5.xlarge --replicas 3 --non-sts --use-local-credentials -y"
+            echo -n $cmd_flags | tee $(results.create-cmd-flags.path) && echo ""
+          fi
+        else
+          echo -n "$(params.create-cmd-flags)" | tee $(results.create-cmd-flags.path) && echo ""
+        fi
+  workspaces:
+    - name: shared-workspace


### PR DESCRIPTION
## Overview
Pipeline for full cycle (provision cluster, install Kuadrant, run tests, upload results, cleanup). It can be used
- for nightlies so that we can see if our test failures are specific for certain infra or not
- for Kuadrant release testing on various infra (if ever needed)

### Known limitations
Pipeline only works if it provisions the cluster (provision-cluster param set to 'true') due to [issues/7680](https://github.com/tektoncd/pipeline/issues/7680)
In order to use existing cluster (it has to be managed by OCM/HCC) you need to comment out the actual cluster provisioning in 'provision-osd-aws/-osd-gcp/-rosa' Task. Workaround would be to skip the required commands in body of Tasks rather than skipping the whole Tasks by when condition in pipeline definition but this is not implemented in this PR.

## Verification Steps
Trigger the pipeline and/or just take a look at my pipeline runs (in trepel namespace)
So far I only tested with OSD on AWS and ROSA but I wanted to create the PR now because it is quite huge.