### PR TITLE
Add rapiDAST pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Deployment
    * Apply nightly pipeline `kubectl apply -k nightly/ -n ${PIPELINE_NAMESPACE}`
    * Apply helm-deploy pipelines `kubectl apply -k deploy/ -n ${PIPELINE_NAMESPACE}`
    * Apply infrastructure pipelines `kubectl apply -k infra/ -n ${PIPELINE_NAMESPACE}`
+   * Apply rapiDAST pipeline `kubectl apply -k dast/ -n ${PIPELINE_NAMESPACE}`
 
 Secrets
 ---
@@ -60,6 +61,12 @@ kubectl create secret generic kua-gcp-credentials --from-file=gcp-osd-ccs-admin-
 - Opaque secret containing ROSA credentials for an IAM user (pipelines provisioning ROSA cluster only). E.g.
 ```shell
 kubectl create secret generic kua-rosa-credentials --from-literal=AWS_ACCOUNT_ID="xxx" --from-literal=AWS_ACCESS_KEY_ID="xxx" --from-literal=AWS_SECRET_ACCESS_KEY="xxx" -n ${PIPELINE_NAMESPACE}
+```
+
+### Resources required for rapiDAST pipeline
+- Opaque secret containing credentials for Google Cloud storage where rapiDAST scan results will be stored. E.g.
+```shell
+kubectl create secret generic rapidast-storage-access-key --from-file=rapidast-sa-rhcl_key.json=/local/path/to/your-service-account_key.json -n ${PIPELINE_NAMESPACE}
 ```
 
 Pipeline execution

--- a/dast/kustomization.yaml
+++ b/dast/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+commonLabels:
+  deployment: kuadrant-qe-pipeline-dast
+
+resources:
+  - ../tasks/dast/
+  - ../tasks/login
+  - ./pipeline.yaml

--- a/dast/pipeline.yaml
+++ b/dast/pipeline.yaml
@@ -1,0 +1,95 @@
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: dast-pipeline
+spec:
+  params:
+    - description: URL of Kubernetes API
+      name: kube-api
+      type: string
+    - description: Subfolder path - results will be stored in this subfolder of rhcl folder in ProdSec Central Storage. Can contain slashes but do not include leading and trailing slashes. Typically v<version> is used
+      name: subfolder-path
+      type: string
+      default: v9.9.9
+    - description: Secret name with cluster credentials
+      name: cluster-credentials
+      type: string
+      default: openshift-pipelines-credentials
+    - description: rapiDAST version - see releases in github.com/RedHatProductSecurity/rapidast
+      name: rapidast-version
+      type: string
+      default: 2.11.0
+    - description: Whether to skip cleanup or not (true/false)
+      name: skip-cleanup
+      type: string
+      default: false
+  tasks:
+    - name: clone-rapidast-repo
+      params:
+        - name: rapidast-version
+          value: $(params.rapidast-version)
+      taskRef:
+        kind: Task
+        name: clone-rapidast-repo
+      workspaces:
+        - name: shared-workspace
+    - name: kubectl-login
+      params:
+        - name: kube-api
+          value: $(params.kube-api)
+        - name: testsuite-image
+          value: quay.io/kuadrant/testsuite-pipelines-tools:latest
+        - name: cluster-credentials
+          value: $(params.cluster-credentials)
+      taskRef:
+        kind: Task
+        name: kubectl-login
+      workspaces:
+        - name: shared-workspace
+    - name: compose-config-file
+      params:
+        - name: kube-api
+          value: $(params.kube-api)
+        - name: cluster-api-token
+          value: $(tasks.kubectl-login.results.token)
+        - name: subfolder-path
+          value: $(params.subfolder-path)
+      taskRef:
+        kind: Task
+        name: compose-config-file
+      runAfter:
+        - kubectl-login
+      workspaces:
+        - name: shared-workspace
+    - name: rapidast-scan
+      taskRef:
+        kind: Task
+        name: rapidast-scan
+      runAfter:
+        - clone-rapidast-repo
+        - compose-config-file
+      workspaces:
+        - name: shared-workspace
+    - name: wait-for-job-to-complete
+      params:
+        - name: job-name
+          value: rapidast-job
+      taskRef:
+        kind: Task
+        name: wait-for-job-to-complete
+      runAfter:
+        - rapidast-scan
+    - name: rapidast-cleanup
+      when:
+        - input: $(params.skip-cleanup)
+          operator: in
+          values: ["false"]
+      taskRef:
+        kind: Task
+        name: rapidast-cleanup
+      runAfter:
+        - wait-for-job-to-complete
+      workspaces:
+        - name: shared-workspace
+  workspaces:
+    - name: shared-workspace

--- a/tasks/dast/clone-rapidast-repo-task.yaml
+++ b/tasks/dast/clone-rapidast-repo-task.yaml
@@ -1,0 +1,30 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: clone-rapidast-repo
+spec:
+  description: 'Clones given rapiDAST version'
+  params:
+    - name: rapidast-version
+      type: string
+  steps:
+  - name: clone-rapidast-repo
+    args:
+      - >-
+        git
+        clone 
+        -b $(params.rapidast-version)
+        --depth '1' 
+        https://github.com/RedHatProductSecurity/rapidast.git
+        $(workspaces.shared-workspace.path)/rapidast
+    command:
+      - /bin/bash
+      - -c
+    computeResources:
+      limits:
+        cpu: 250m
+        memory: 128Mi
+    image: quay.io/kuadrant/testsuite-pipelines-tools:latest
+    imagePullPolicy: Always
+  workspaces:
+  - name: shared-workspace

--- a/tasks/dast/compose-config-file-task.yaml
+++ b/tasks/dast/compose-config-file-task.yaml
@@ -1,0 +1,96 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: compose-config-file
+spec:
+  description: 'Compose config file for rapiDAST scan'
+  params:
+    - name: kube-api
+      type: string
+    - name: subfolder-path
+      type: string
+    - name: cluster-api-token
+      type: string
+  workspaces:
+    - name: shared-workspace
+  volumes: 
+    - secret: 
+        secretName: rapidast-storage-access-key
+      name: rapidast-storage-access-key
+  steps:
+    - computeResources:
+        limits:
+          cpu: '100m'
+          memory: 64Mi
+      image: quay.io/kuadrant/testsuite-pipelines-tools:latest
+      imagePullPolicy: Always
+      name: compose-config-file
+      volumeMounts:
+        - name: rapidast-storage-access-key
+          mountPath: /rapidast-storage-access-key
+      script: |
+        #!/usr/bin/env bash
+        set -vo pipefail
+
+        cp /rapidast-storage-access-key/rapidast-sa-rhcl_key.json $(workspaces.shared-workspace.path)/rapidast-sa-rhcl_key.json
+
+        # Read rapiDAST configuration from heredoc
+        read -r -d '' config <<EOF
+        config:
+            configVersion: 4
+            googleCloudStorage:
+                keyFile: "/opt/rapidast/results/rapidast-sa-rhcl_key.json"
+                bucketName: "secaut-bucket"
+                directory: "rhcl/$(params.subfolder-path)"
+        application:
+            shortName: "rhcl-scan"
+            url: "$(params.kube-api)"
+        general:
+            authentication:
+                type: "http_header"
+                parameters:
+                    name: "Authorization"
+                    value: "Bearer $(params.cluster-api-token)"
+            container:
+                type: "none"
+        scanners:
+            zap:
+                apiScan:
+                    apis:
+                        apiUrl: "$(params.kube-api)/openapi/v3/apis/kuadrant.io/v1"
+                passiveScan:
+                    disabledRules: "2,10015,10027,10096,10024,10054"
+                miscOptions:
+                    enableUI: False
+                    updateAddons: False
+            zap_1:
+                apiScan:
+                    apis:
+                        apiUrl: "$(params.kube-api)/openapi/v3/apis/limitador.kuadrant.io/v1alpha1"
+                passiveScan:
+                    disabledRules: "2,10015,10027,10096,10024,10054"
+                miscOptions:
+                    enableUI: False
+                    updateAddons: False
+            zap_2:
+                apiScan:
+                    apis:
+                        apiUrl: "$(params.kube-api)/openapi/v3/apis/authorino.kuadrant.io/v1beta3"
+                passiveScan:
+                    disabledRules: "2,10015,10027,10096,10024,10054"
+                miscOptions:
+                    enableUI: False
+                    updateAddons: False
+            zap_3:
+                apiScan:
+                    apis:
+                        apiUrl: "$(params.kube-api)/openapi/v3/apis/operator.authorino.kuadrant.io/v1beta1"
+                passiveScan:
+                    disabledRules: "2,10015,10027,10096,10024,10054"
+                miscOptions:
+                    enableUI: False
+                    updateAddons: False
+        EOF
+
+        # Store the rapidast-config.yaml for rapiDAST to shared workspace
+        echo "$config" > $(workspaces.shared-workspace.path)/rapidast-config.yaml

--- a/tasks/dast/kustomization.yaml
+++ b/tasks/dast/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - clone-rapidast-repo-task.yaml
+  - compose-config-file-task.yaml
+  - rapidast-scan-task.yaml
+  - rapidast-cleanup-task.yaml
+  - wait-for-job-to-complete-task.yaml

--- a/tasks/dast/rapidast-cleanup-task.yaml
+++ b/tasks/dast/rapidast-cleanup-task.yaml
@@ -1,0 +1,29 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: rapidast-cleanup
+spec:
+  description: 'rapiDAST cleanup'
+  workspaces:
+    - name: shared-workspace
+  steps:
+    - computeResources:
+        limits:
+          cpu: '100m'
+          memory: 64Mi
+      image: quay.io/kuadrant/testsuite-pipelines-tools:latest
+      imagePullPolicy: Always
+      env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+      name: rapidast-cleanup
+      script: |
+        #!/usr/bin/env bash
+        set -euvo pipefail
+
+        helm uninstall rapidast || true
+
+        kubectl delete pvc rapidast-pvc -n "$NAMESPACE" --ignore-not-found
+

--- a/tasks/dast/rapidast-scan-task.yaml
+++ b/tasks/dast/rapidast-scan-task.yaml
@@ -1,0 +1,24 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: rapidast-scan
+spec:
+  description: 'rapiDAST scan'
+  workspaces:
+    - name: shared-workspace
+  steps:
+    - computeResources:
+        limits:
+          cpu: '100m'
+          memory: 64Mi
+      image: quay.io/kuadrant/testsuite-pipelines-tools:latest
+      imagePullPolicy: Always
+      name: rapidast-scan
+      script: |
+        #!/usr/bin/env bash
+        set -evo pipefail
+
+        helm uninstall rapidast || true
+
+        helm install rapidast $(workspaces.shared-workspace.path)/rapidast/helm/chart/ --set-file rapidastConfig=$(workspaces.shared-workspace.path)/rapidast-config.yaml --set pvc=$(workspaces.shared-workspace.claim)
+

--- a/tasks/dast/wait-for-job-to-complete-task.yaml
+++ b/tasks/dast/wait-for-job-to-complete-task.yaml
@@ -1,0 +1,51 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: wait-for-job-to-complete
+spec:
+  description: 'Wait for given Job to complete'
+  params:
+    - name: job-name
+      type: string
+  steps:
+    - name: wait-for-job-to-complete
+      computeResources:
+        limits:
+          cpu: '100m'
+          memory: 64Mi
+      image: quay.io/kuadrant/testsuite-pipelines-tools:latest
+      imagePullPolicy: Always
+      env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+      script: |
+        #!/bin/sh
+        set -euvo pipefail
+
+        JOB_NAME="$(params.job-name)"
+        MAX_TRIES=24 # max 2 minutes
+        TRY=0
+
+        echo "Waiting for Job '$JOB_NAME' in namespace '$NAMESPACE' to complete..."
+
+        while [ "$TRY" -lt "$MAX_TRIES" ]; do
+          status=$(kubectl get job "$JOB_NAME" -n "$NAMESPACE" -o jsonpath='{.status.conditions[?(@.type=="Complete")].status}' || true)
+
+          if [ "$status" = "True" ]; then
+            echo "Job completed!"
+            break
+          fi
+
+          failed=$(kubectl get job "$JOB_NAME" -n "$NAMESPACE" -o jsonpath='{.status.conditions[?(@.type=="Failed")].status}' || true)
+          if [ "$failed" = "True" ]; then
+            echo "Job failed!"
+            exit 1
+          fi
+
+          TRY=$((TRY + 1))
+          echo "Job not finished yet... waiting 5s"
+          sleep 5
+        done
+

--- a/tasks/login/kubectl-login-task.yaml
+++ b/tasks/login/kubectl-login-task.yaml
@@ -18,24 +18,27 @@ spec:
       description: Path to new kubeconfig in the workspace
     - name: ocp-version
       description: OCP cluster version
+    - name: token
+      description: OCP Token
   steps:
-    - args:
-        - >-
-          export CLUSTER_NAME=$(echo $(params.kube-api) | sed 's/.*api\.\([^\.]*\).*/\1/') &&
-          export KUBECONFIG=$(workspaces.shared-workspace.path)/${CLUSTER_NAME} &&
-          export OAUTH_URL=$(echo $(params.kube-api) | sed -e 's/api/oauth-openshift.apps/' -e 's/\(.*\):.*/\1/')/oauth/authorize &&
-          export TOKEN=$(curl -XPOST -kis --data response_type=token --data client_id=openshift-challenging-client -u ${KUBE_USER}:${KUBE_PASSWORD} ${OAUTH_URL} | grep "Location:" | sed 's/.*access_token=\([^&]*\).*/\1/') &&
-          kubectl config set-cluster ctx --server $(params.kube-api) --insecure-skip-tls-verify=true &&
-          kubectl config set-credentials user --token=${TOKEN} &&
-          kubectl config set-context ctx --user=user --cluster=ctx &&
-          kubectl config use-context ctx &&
-          echo -n ${KUBECONFIG} | tee $(results.kubeconfig-path.path) &&
-          export OCP_VERSION=$(kubectl get clusterversion -o jsonpath='{.items[].status.history[0].version}') &&
-          echo -n ${OCP_VERSION%.*} | tee $(results.ocp-version.path)
-      command:
-        - /bin/bash
-        - -cveo
-        - pipefail
+    - script: |
+        #!/usr/bin/env bash
+        set -vo pipefail
+
+        export CLUSTER_NAME=$(echo $(params.kube-api) | sed 's/.*api\.\([^\.]*\).*/\1/')
+        export KUBECONFIG=$(workspaces.shared-workspace.path)/${CLUSTER_NAME}
+        export OAUTH_URL=$(echo $(params.kube-api) | sed -e 's/api/oauth-openshift.apps/' -e 's/\(.*\):.*/\1/')/oauth/authorize
+        export TOKEN=$(curl -XPOST -kis --data response_type=token --data client_id=openshift-challenging-client -u ${KUBE_USER}:${KUBE_PASSWORD} ${OAUTH_URL} | grep "Location:" | sed 's/.*access_token=\([^&]*\).*/\1/')
+        echo -n ${TOKEN} | tee $(results.token.path)
+
+        kubectl config set-cluster ctx --server $(params.kube-api) --insecure-skip-tls-verify=true
+        kubectl config set-credentials user --token=${TOKEN}
+        kubectl config set-context ctx --user=user --cluster=ctx
+        kubectl config use-context ctx
+
+        echo -n ${KUBECONFIG} | tee $(results.kubeconfig-path.path)
+        export OCP_VERSION=$(kubectl get clusterversion -o jsonpath='{.items[].status.history[0].version}')
+        echo -n ${OCP_VERSION%.*} | tee $(results.ocp-version.path)
       computeResources:
         limits:
           cpu: '250m'


### PR DESCRIPTION
## rapiDAST pipeline

This PR adds rapiDAST pipeline. It scans four custom Kubernetes APIs the Kuadrant offers and stores the result in Google Cloud Storage.

## Verification Steps

Run the pipeline or take a look at my run in `trepel` ns. 