### PR TITLE
Use coschedule:workspaces in DAST pipeline

### DIFF
--- a/dast/pipeline.yaml
+++ b/dast/pipeline.yaml
@@ -2,6 +2,8 @@ apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: dast-pipeline
+  annotations:
+    pipelinesascode.tekton.dev/coschedule: workspaces
 spec:
   params:
     - description: URL of Kubernetes API


### PR DESCRIPTION
## Overview

DAST pipeline run rapiDAST scan via Helm. A new pod where the scan is performed is created as part of running the Helm chart. The file (containing key for scan result storage) needs to be accessible for the pod. In order to do so the Helm uses the same PVC as the pipeline (and before running Helm pipeline makes sure the file is stored in that PVC). The PVC name is then passed to Helm chart.

This means that both pipeline pod and Helm pod use the same PVC which leads to "Multi-attach" error in Helm pod (PVC is in already use by pipeline that triggered the Helm). To avoid this the DAST pipeline need to have `coschedule:workspaces` set. This allow for Helm pod to access PVC (the Task that triggers Helm is not configured to use workspace so it does not use the PVC).

## Verification steps

Trigger the pipeline or just take a look at las tPipelineRun of dast pipeline in kuadrant-pipelines ns (I already applied the PR there). If you plan to run the pipeline make sure that `coschedule:pipelineruns` is set via tektonconfig CR first.