### PR TITLE
Add parameter for helm install command flags

### DIFF
--- a/dast/pipeline.yaml
+++ b/dast/pipeline.yaml
@@ -20,7 +20,7 @@ spec:
     - description: rapiDAST version - see releases in github.com/RedHatProductSecurity/rapidast
       name: rapidast-version
       type: string
-      default: 2.11.0
+      default: 2.12.0
     - description: Whether to skip cleanup or not (true/false)
       name: skip-cleanup
       type: string

--- a/deploy/pipeline-nightly-update.yaml
+++ b/deploy/pipeline-nightly-update.yaml
@@ -27,6 +27,10 @@ spec:
     name: keycloak-channel
     type: string
     default: stable-v26
+  - description: Additional flags for helm install command, example '--set=kuadrant.installPlanApproval=Manual --set=kuadrant.startingCSV=kuadrant-operator.v1.2.0'
+    name: helm-install-flags
+    type: string
+    default: ' '
   tasks:
   - name: clone
     taskRef:
@@ -92,6 +96,8 @@ spec:
         value: $(params.operator-name)
       - name: kubeconfig-path
         value: $(tasks.kubectl-login.results.kubeconfig-path)
+      - name: helm-install-flags
+        value: $(params.helm-install-flags)
     runAfter:
     - helm-uninstall
     taskRef:

--- a/deploy/pipeline.yaml
+++ b/deploy/pipeline.yaml
@@ -35,6 +35,10 @@ spec:
     name: keycloak-channel
     type: string
     default: stable-v26
+  - description: Additional flags for helm install command, example '--set=kuadrant.installPlanApproval=Manual --set=kuadrant.startingCSV=kuadrant-operator.v1.2.0'
+    name: helm-install-flags
+    type: string
+    default: ' '
   tasks:
   - name: clone
     taskRef:
@@ -94,6 +98,8 @@ spec:
         value: $(params.operator-name)
       - name: kubeconfig-path
         value: $(tasks.kubectl-login.results.kubeconfig-path)
+      - name: helm-install-flags
+        value: $(params.helm-install-flags)
     runAfter:
     - helm-uninstall
     taskRef:

--- a/tasks/deploy/helm-install-task.yaml
+++ b/tasks/deploy/helm-install-task.yaml
@@ -25,26 +25,26 @@ spec:
     - description: Kuadrant operator name. 'kuadrant-operator' or 'rhcl-operator'
       name: operator-name
       type: string
+    - description: Additional flags for helm install command, example '--set=kuadrant.installPlanApproval=Manual --set=kuadrant.startingCSV=kuadrant-operator.v1.2.0'"
+      name: helm-install-flags
+      type: string
   steps:
   - name: helm-install-operators
-    args:
-      - install
-      - -n=default
-      - --values=$(workspaces.shared-workspace.path)/kuadrant-helm-install/values.yaml
-      - --values=/mount/values-additional-manifests/additionalManifests.yaml
-      - --set=kuadrant.indexImage=$(params.index-image)
-      - --set=kuadrant.channel=$(params.channel)
-      - --set=kuadrant.operatorName=$(params.operator-name)
-      - --set=istio.istioProvider=$(params.istio-provider)
-      - --set=gatewayAPI.version=$(params.gateway-crd)
-      - --set=tools.keycloak.operator.channel=$(params.keycloak-channel)
-      - --set=tools.enabled=true
-      - --wait
-      - --debug
-      - kuadrant-operators
-      - $(workspaces.shared-workspace.path)/kuadrant-helm-install/operators/
-    command:
-      - helm
+    script: |
+      helm install -n=default \
+      --values=$(workspaces.shared-workspace.path)/kuadrant-helm-install/values.yaml \
+      --values=/mount/values-additional-manifests/additionalManifests.yaml \
+      --set=kuadrant.indexImage=$(params.index-image) \
+      --set=kuadrant.channel=$(params.channel) \
+      --set=kuadrant.operatorName=$(params.operator-name) \
+      --set=istio.istioProvider=$(params.istio-provider) \
+      --set=gatewayAPI.version=$(params.gateway-crd) \
+      --set=tools.keycloak.operator.channel=$(params.keycloak-channel) \
+      --set=tools.enabled=true \
+      $(params.helm-install-flags) \
+      --wait --debug \
+      kuadrant-operators \
+      $(workspaces.shared-workspace.path)/kuadrant-helm-install/operators/
     volumeMounts:
       - mountPath: /mount/values-additional-manifests
         name: values-additional-manifests
@@ -54,25 +54,21 @@ spec:
     image: quay.io/kuadrant/testsuite-pipelines-tools:latest
     imagePullPolicy: Always
   - name: helm-install-instances
-    args:
-      - install
-      - -n=default
-      - --values=$(workspaces.shared-workspace.path)/kuadrant-helm-install/values.yaml
-      - --values=/mount/values-additional-manifests/additionalManifests.yaml
-      - --set=kuadrant.indexImage=$(params.index-image)
-      - --set=kuadrant.channel=$(params.channel)
-      - --set=kuadrant.operatorName=$(params.operator-name)
-      - --set=istio.istioProvider=$(params.istio-provider)
-      - --set=gatewayAPI.version=$(params.gateway-crd)
-      - --set=tools.keycloak.operator.channel=$(params.keycloak-channel)
-      - --set=tools.enabled=true
-      - --timeout=10m0s
-      - --wait
-      - --debug
-      - kuadrant-instances
-      - $(workspaces.shared-workspace.path)/kuadrant-helm-install/instances/
-    command:
-      - helm
+    script: |
+      helm install -n=default \
+      --values=$(workspaces.shared-workspace.path)/kuadrant-helm-install/values.yaml \
+      --values=/mount/values-additional-manifests/additionalManifests.yaml \
+      --set=kuadrant.indexImage=$(params.index-image) \
+      --set=kuadrant.channel=$(params.channel) \
+      --set=kuadrant.operatorName=$(params.operator-name) \
+      --set=istio.istioProvider=$(params.istio-provider) \
+      --set=gatewayAPI.version=$(params.gateway-crd) \
+      --set=tools.keycloak.operator.channel=$(params.keycloak-channel) \
+      --set=tools.enabled=true \
+      $(params.helm-install-flags) \
+      --wait --debug --timeout=10m0s \
+      kuadrant-instances \
+      $(workspaces.shared-workspace.path)/kuadrant-helm-install/instances/
     volumeMounts:
       - mountPath: /mount/values-additional-manifests
         name: values-additional-manifests


### PR DESCRIPTION
## Overview

Add parameter allowing to specify any flags for Helm install command allowing to override whatever is defined in values.yaml.

What hes been done
rapiDAST version bump, a new version has been released: https://github.com/RedHatProductSecurity/rapidast/releases

`--set=kuadrant.installPlanApproval=Automatic` has been added as a default value. Reason is that empty string does not count as default value so it makes the parameter required which I did not want to. This default value effectively does nothing because it it set as Automatic in values.yaml anyway.

Refactoring the Task to use `.script` rather than `.command` and `.args`.

## Verification Steps

Run the deploy pipeline or take a look at two PipelineRuns in my ns (once the param was left empty).