### PR TITLE
Support for outside-RHT-VPN clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ kubectl create cm rp-ca-bundle --from-file=tls-ca-bundle.pem=./tls-ca-bundle.pem
 kubectl create cm pipeline-settings --from-file=settings.local.yaml=./settings.local.yaml -n ${PIPELINE_NAMESPACE}
 ```
 
+- Opaque Secret named additional-auth-entries containing "auth" sections that will be added to global pull secret. Useful if consuming images from private registries.
+```shell
+export ADDITIONAL_AUTH_ENTRIES='"desired.registry.io": {"auth": "base64-encoded-creds"}'
+kubectl create secret generic additional-auth-entries --from-literal="additional-auth-entries=$ADDITIONAL_AUTH_ENTRIES" -n "${PIPELINE_NAMESPACE}"
+```
+
 ### Helm pipelines
 - Opaque Secret named values-additional-manifests containing secrets for testsuite run. Example: https://github.com/azgabur/kuadrant-helm-install/blob/main/example-additionalManifests.yaml
 ```shell

--- a/main/provision-install-test-pipeline.yaml
+++ b/main/provision-install-test-pipeline.yaml
@@ -59,7 +59,7 @@ spec:
       name: keycloak-channel
       type: string
     - default: ' '
-      description: Additional flags for helm install command, example '--set=kuadrant.installPlanApproval=Manual --set=kuadrant.startingCSV=kuadrant-operator.v1.2.0'"
+      description: Additional flags for helm install command, example '--set=kuadrant.installPlanApproval=Manual --set=kuadrant.startingCSV=kuadrant-operator.v1.2.0'
       name: helm-install-flags
       type: string
 # Testsuite related parameters
@@ -330,6 +330,25 @@ spec:
       workspaces:
         - name: shared-workspace
           workspace: shared-workspace
+    - name: prepare-for-rhcl-rc-install
+      when:
+        - input: "$(params.operator-name)"
+          operator: in
+          values: ['rhcl-operator']
+        - input: "$(params.index-image)"
+          operator: notin
+          values: ['']
+      params:
+        - name: kubeconfig-path
+          value: $(tasks.kubectl-login.results.kubeconfig-path)
+      runAfter:
+        - helm-uninstall
+      taskRef:
+        kind: Task
+        name: prepare-for-rhcl-rc-install
+      workspaces:
+        - name: shared-workspace
+          workspace: shared-workspace
     - name: helm-install
       params:
         - name: index-image
@@ -350,6 +369,7 @@ spec:
           value: $(params.helm-install-flags)
       runAfter:
         - helm-uninstall
+        - prepare-for-rhcl-rc-install
       taskRef:
         kind: Task
         name: helm-install

--- a/tasks/infra/kustomization.yaml
+++ b/tasks/infra/kustomization.yaml
@@ -13,4 +13,4 @@ resources:
   - rosa-login-task.yaml
   - provision-rosa-task.yaml
   - delete-rosa-task.yaml
-
+  - prepare-for-rhcl-rc-install-task.yaml

--- a/tasks/infra/prepare-for-rhcl-rc-install-task.yaml
+++ b/tasks/infra/prepare-for-rhcl-rc-install-task.yaml
@@ -1,0 +1,54 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: prepare-for-rhcl-rc-install
+spec:
+  description: Prepare for RHCL RC installation
+  params:
+    - name: kubeconfig-path
+      type: string
+  steps:
+    - computeResources:
+        limits:
+          cpu: '200m'
+          memory: 256Mi
+      env:
+        - name: KUBECONFIG
+          value: $(params.kubeconfig-path)
+        - name: ADDITIONAL_AUTH_ENTRIES
+          valueFrom:
+            secretKeyRef:
+              key: additional-auth-entries
+              name: additional-auth-entries
+      image: quay.io/kuadrant/testsuite-pipelines-tools:latest
+      imagePullPolicy: Always
+      name: prepare-for-rhcl-rc-install
+      script: |
+        #!/usr/bin/env bash
+        set -evo pipefail
+
+        # Creates ICSP that allow to mirroring to brew
+        kubectl apply -f -<<EOF
+            apiVersion: operator.openshift.io/v1alpha1
+            kind: ImageContentSourcePolicy
+            metadata:
+              name: errata-from-brew
+            spec:
+              repositoryDigestMirrors:
+              - mirrors:
+                - brew.registry.redhat.io/rh-osbs
+                source: registry-proxy.engineering.redhat.com/rh-osbs
+              - mirrors:
+                  - brew.registry.redhat.io/rhcl-1
+                source: registry.redhat.io/rhcl-1
+        EOF
+
+        # update global pull secret
+        kubectl get secret/pull-secret -n openshift-config -o jsonpath='{.data.\.dockerconfigjson}' | base64 -d > current-auths.json
+
+        jq --argjson new_auths "{${ADDITIONAL_AUTH_ENTRIES}}" '.auths += $new_auths' current-auths.json > updated-auths.json
+
+        kubectl create secret generic pull-secret --from-file=.dockerconfigjson=updated-auths.json --type=kubernetes.io/dockerconfigjson --dry-run=client -o yaml | kubectl apply -n openshift-config -f -
+  workspaces:
+    - name: shared-workspace
+


### PR DESCRIPTION
## Overview

In order to install downstream release candidate to cluster that is outside RHT VPN one has to create ICSP (for image mirroring to brew) and update global pull secret to allow for pulling images from brew.

### Verification Steps
Take a look at my pipeline run in my ns. Alternatively you can run the pipeline yourself:

```shell
export PIPELINE_NAMESPACE=your-pipeline-ns
export ADDITIONAL_AUTH_ENTRIES='"brew.registry.redhat.io": {"auth": "your-base64-encoded-creds"}'
kubectl create secret generic additional-auth-entries --from-literal="additional-auth-entries=$ADDITIONAL_AUTH_ENTRIES" -n "${PIPELINE_NAMESPACE}"
kubectl apply -k main/ -n ${PIPELINE_NAMESPACE}
```

And trigger the pipeline via UI. You can use my index image for testing this:
https://quay.io/repository/trepel/index-from-errata?tab=tags&tag=latest

Make sure you use `rhcl-operator` as a value for `operator-name` input param.

To validate it is enough to see that ICSP were created and global pull secret (it is called `pull-secret` and it is in `openshift-config` ns) got updated.
