### PR TITLE
Transfer helm chart repo

### DIFF
--- a/tasks/deploy/clone-task.yaml
+++ b/tasks/deploy/clone-task.yaml
@@ -11,7 +11,7 @@ spec:
         clone 
         -b main 
         --depth '1' 
-        https://github.com/azgabur/kuadrant-helm-install 
+        https://github.com/Kuadrant/helm-charts-olm.git
         $(workspaces.shared-workspace.path)/kuadrant-helm-install
     command:
       - /bin/bash


### PR DESCRIPTION
Helm charts repo moved to Kuadrant org: https://github.com/Kuadrant/helm-charts-olm

The old repo path will be automatically redirected as promised here: https://docs.github.com/en/repositories/creating-and-managing-repositories/transferring-a-repository#whats-transferred-with-a-repository