### PR TITLE
Workspace not needed for cluster credentials removal

### DIFF
--- a/infra/delete-aro-pipeline.yaml
+++ b/infra/delete-aro-pipeline.yaml
@@ -21,8 +21,6 @@ spec:
       taskRef:
         kind: Task
         name: cluster-secret-cleanup
-      workspaces:
-        - name: shared-workspace
     - name: delete-aro
       params:
         - name: cluster-name

--- a/infra/delete-osd-pipeline.yaml
+++ b/infra/delete-osd-pipeline.yaml
@@ -48,8 +48,6 @@ spec:
       taskRef:
         kind: Task
         name: cluster-secret-cleanup
-      workspaces:
-        - name: shared-workspace
     - name: delete-osd
       params:
         - name: cluster-id

--- a/infra/delete-rosa-pipeline.yaml
+++ b/infra/delete-rosa-pipeline.yaml
@@ -56,8 +56,6 @@ spec:
       taskRef:
         kind: Task
         name: cluster-secret-cleanup
-      workspaces:
-        - name: shared-workspace
     - name: delete-rosa
       params:
         - name: cluster-id

--- a/main/provision-install-test-pipeline.yaml
+++ b/main/provision-install-test-pipeline.yaml
@@ -278,9 +278,6 @@ spec:
         - get-osd-credentials
       workspaces:
         - name: shared-workspace
-      workspaces:
-        - name: shared-workspace
-          workspace: shared-workspace
     - name: check-image-existence
       when:
         - input: "$(params.index-image)"
@@ -489,5 +486,3 @@ spec:
       taskRef:
         kind: Task
         name: cluster-secret-cleanup
-      workspaces:
-        - name: shared-workspace

--- a/tasks/infra/cluster-secret-cleanup-task.yaml
+++ b/tasks/infra/cluster-secret-cleanup-task.yaml
@@ -25,6 +25,4 @@ spec:
         set -evo pipefail
 
         kubectl delete --ignore-not-found secret "$(params.cluster-name)-credentials" -n ${NAMESPACE}
-  workspaces:
-    - name: shared-workspace
 


### PR DESCRIPTION
## Overview

Workspace not needed for cluster credentials removal.

What has been done:
- removed workspace definition from Task
- removed workspace definition in all the Pipelines that use the Task
- fixed double workspace definition from main/provision-install-test-pipeline.yaml

### Verification Steps
kubectl apply -k main -n ${PIPELINE_NAMESPACE}
- to validate the "double workspace definition fix

see the pipeline run in trepel ns, or trigger it yourself using the same parameters.


