### PR TITLE
Add pipeline for upgrade testing

### DIFF
--- a/infra/delete-rosa-pipeline.yaml
+++ b/infra/delete-rosa-pipeline.yaml
@@ -17,7 +17,7 @@ spec:
       description: 'What OCM instance to use, either ''staging'' or ''production'''
       name: ocm-instance
       type: string
-    - description: ROSA cluster ID that is to be deleted
+    - description: ROSA cluster name that is to be deleted
       name: cluster-name
       type: string
   tasks:

--- a/infra/osd-aws-pipeline.yaml
+++ b/infra/osd-aws-pipeline.yaml
@@ -45,6 +45,8 @@ spec:
           value: $(params.create-cmd-flags)
         - name: cluster-name
           value: $(params.cluster-name)
+        - name: provision-cluster
+          value: true
       taskRef:
         kind: Task
         name: provision-osd-aws
@@ -67,6 +69,8 @@ spec:
       params:
         - name: cluster-id
           value: $(tasks.provision-osd-aws.results.cluster-id)
+        - name: provision-cluster
+          value: true
       taskRef:
         kind: Task
         name: get-osd-credentials

--- a/infra/osd-gcp-pipeline.yaml
+++ b/infra/osd-gcp-pipeline.yaml
@@ -45,6 +45,8 @@ spec:
           value: $(params.create-cmd-flags)
         - name: cluster-name
           value: $(params.cluster-name)
+        - name: provision-cluster
+          value: true
       taskRef:
         kind: Task
         name: provision-osd-gcp
@@ -67,6 +69,8 @@ spec:
       params:
         - name: cluster-id
           value: $(tasks.provision-osd-gcp.results.cluster-id)
+        - name: provision-cluster
+          value: true
       taskRef:
         kind: Task
         name: get-osd-credentials

--- a/infra/rosa-pipeline.yaml
+++ b/infra/rosa-pipeline.yaml
@@ -55,6 +55,8 @@ spec:
           value: $(params.cluster-name)
         - name: region
           value: $(params.region)
+        - name: provision-cluster
+          value: true
       taskRef:
         kind: Task
         name: provision-rosa
@@ -77,6 +79,8 @@ spec:
       params:
         - name: cluster-id
           value: $(tasks.provision-rosa.results.cluster-id)
+        - name: provision-cluster
+          value: true
       taskRef:
         kind: Task
         name: get-osd-credentials

--- a/main/kustomization.yaml
+++ b/main/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
   - ../tasks/provision-install-test/
   - pipeline.yaml
   - provision-install-test-pipeline.yaml
+  - provision-upgrade-test-pipeline.yaml

--- a/main/provision-upgrade-test-pipeline.yaml
+++ b/main/provision-upgrade-test-pipeline.yaml
@@ -1,7 +1,7 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: provision-install-test-pipeline
+  name: provision-upgrade-test-pipeline
 spec:
   params:
 # Cluster related parameters
@@ -37,16 +37,16 @@ spec:
       description: Cluster creation flags. Leave empty to use defaults (they depend on Cloud Provider)
       name: create-cmd-flags
       type: string
-# Kuadrant/RHCL installation related parameters
-    - default: quay.io/kuadrant/kuadrant-operator-catalog:v1.2.0
-      description: Kuadrant/RHCL index image, leave empty to install current RHCL GA
+# Kuadrant/RHCL installation/upgrade related parameters
+    - default: ' '
+      description: Kuadrant/RHCL index image, must contain proper bundle chain for upgrade
       name: index-image
       type: string
     - default: stable
       description: Kuadrant channel (stable, preview)
       name: channel
       type: string
-    - default: kuadrant-operator
+    - default: rhcl-operator
       description: Operator name (kuadrant-operator, rhcl-operator)
       name: operator-name
       type: string
@@ -62,8 +62,8 @@ spec:
       description: Keycloak subscription channel
       name: keycloak-channel
       type: string
-    - default: ' '
-      description: Additional flags for helm install command, example '--set=kuadrant.installPlanApproval=Manual --set=kuadrant.startingCSV=kuadrant-operator.v1.2.0'
+    - default: '--set=kuadrant.installPlanApproval=Manual --set=kuadrant.startingCSV=rhcl-operator.v1.1.0'
+      description: Additional flags for helm install command, specify desired 'upgrade from' version"
       name: helm-install-flags
       type: string
 # Testsuite related parameters
@@ -75,9 +75,13 @@ spec:
       description: Openshift project
       name: project
       type: string
+    - default: smoke
+      description: Makefile target for pre-upgrade tests
+      name: pre-upgrade-make-target
+      type: string
     - default: test
-      description: Makefile target for tests
-      name: make-target
+      description: Makefile target for post-upgrade tests
+      name: post-upgrade-make-target
       type: string
     - default: ' '
       description: Pytest flags to use with Make (flags="${pytest-flags}" make kuadrant)
@@ -376,14 +380,14 @@ spec:
       workspaces:
         - name: shared-workspace
           workspace: shared-workspace
-    - name: run-tests
+    - name: run-tests-pre-upgrade
       params:
         - name: testsuite-image
           value: $(params.testsuite-image)
         - name: project
           value: $(params.project)
         - name: make-target
-          value: $(params.make-target)
+          value: $(params.pre-upgrade-make-target)
         - name: pytest-flags
           value: $(params.pytest-flags)
         - name: settings-cm
@@ -396,6 +400,42 @@ spec:
           value: $(tasks.get-osd-credentials.results.credentials-secret)
       runAfter:
         - helm-install
+      taskRef:
+        kind: Task
+        name: run-tests
+      workspaces:
+        - name: shared-workspace
+    - name: upgrade-to-latest
+      params:
+        - name: kubeconfig-path
+          value: $(tasks.kubectl-login.results.kubeconfig-path)
+      runAfter:
+        - run-tests-pre-upgrade
+      taskRef:
+        kind: Task
+        name: upgrade-to-latest
+      workspaces:
+        - name: shared-workspace
+    - name: run-tests-post-upgrade
+      params:
+        - name: testsuite-image
+          value: $(params.testsuite-image)
+        - name: project
+          value: $(params.project)
+        - name: make-target
+          value: $(params.post-upgrade-make-target)
+        - name: pytest-flags
+          value: $(params.pytest-flags)
+        - name: settings-cm
+          value: $(params.settings-cm)
+        - name: additional-env
+          value: $(params.additional-env)
+        - name: kubeconfig-path
+          value: $(tasks.kubectl-login.results.kubeconfig-path)
+        - name: cluster-credentials
+          value: $(tasks.get-osd-credentials.results.credentials-secret)
+      runAfter:
+        - upgrade-to-latest
       taskRef:
         kind: Task
         name: run-tests
@@ -414,13 +454,13 @@ spec:
         - name: testsuite-image
           value: $(params.testsuite-image)
         - name: make-target
-          value: $(params.make-target)
+          value: $(params.post-upgrade-make-target)
         - name: rp-project
           value: $(params.rp-project)
         - name: ocp-version
           value: $(tasks.kubectl-login.results.ocp-version)
       runAfter:
-        - run-tests
+        - run-tests-post-upgrade
       taskRef:
         kind: Task
         name: upload-results
@@ -436,7 +476,7 @@ spec:
           value: $(tasks.kubectl-login.results.kubeconfig-path)
       runAfter:
         - upload-results
-        - run-tests
+        - run-tests-post-upgrade
       taskRef:
         kind: Task
         name: helm-uninstall

--- a/tasks/deploy/helm-install-task.yaml
+++ b/tasks/deploy/helm-install-task.yaml
@@ -29,6 +29,30 @@ spec:
       name: helm-install-flags
       type: string
   steps:
+  - name: helm-install-tools-operators
+    script: >
+      helm install -n=default
+      --repo https://kuadrant.io/helm-charts-olm
+      --wait --debug
+      tools-operators
+      tools-operators
+    env:
+      - name: KUBECONFIG
+        value: $(params.kubeconfig-path)
+    image: quay.io/kuadrant/testsuite-pipelines-tools:latest
+    imagePullPolicy: Always
+  - name: helm-install-tools-instances
+    script: >
+      helm install -n=default
+      --repo https://kuadrant.io/helm-charts-olm
+      --wait --debug --timeout=10m0s
+      tools-instances
+      tools-instances
+    env:
+      - name: KUBECONFIG
+        value: $(params.kubeconfig-path)
+    image: quay.io/kuadrant/testsuite-pipelines-tools:latest
+    imagePullPolicy: Always
   - name: helm-install-operators
     script: >
       helm install -n=default
@@ -72,30 +96,6 @@ spec:
     volumeMounts:
       - mountPath: /mount/values-additional-manifests
         name: values-additional-manifests
-    env:
-      - name: KUBECONFIG
-        value: $(params.kubeconfig-path)
-    image: quay.io/kuadrant/testsuite-pipelines-tools:latest
-    imagePullPolicy: Always
-  - name: helm-install-tools-operators
-    script: >
-      helm install -n=default
-      --repo https://kuadrant.io/helm-charts-olm
-      --wait --debug
-      tools-operators
-      tools-operators
-    env:
-      - name: KUBECONFIG
-        value: $(params.kubeconfig-path)
-    image: quay.io/kuadrant/testsuite-pipelines-tools:latest
-    imagePullPolicy: Always
-  - name: helm-install-tools-instances
-    script: >
-      helm install -n=default
-      --repo https://kuadrant.io/helm-charts-olm
-      --wait --debug --timeout=10m0s
-      tools-instances
-      tools-instances
     env:
       - name: KUBECONFIG
         value: $(params.kubeconfig-path)

--- a/tasks/infra/get-osd-credentials-task.yaml
+++ b/tasks/infra/get-osd-credentials-task.yaml
@@ -7,6 +7,8 @@ spec:
   params:
     - name: cluster-id
       type: string
+    - name: provision-cluster
+      type: string
   results:
     - name: password
       description: kubeadmin password
@@ -67,7 +69,9 @@ spec:
 
         # Create secret with cluster credentials
         echo -n "${cluster_name}-credentials" | tee $(results.credentials-secret.path)
-        kubectl create secret generic "${cluster_name}-credentials" --from-literal=KUBE_USER="kubeadmin" --from-literal=KUBE_PASSWORD="$password" -n ${NAMESPACE}
+        if [[ "$(params.provision-cluster)" == "true" ]]; then
+            kubectl create secret generic "${cluster_name}-credentials" --from-literal=KUBE_USER="kubeadmin" --from-literal=KUBE_PASSWORD="$password" -n ${NAMESPACE}
+        fi
 
         # Store api_url in shared workspace so that kubectl-login Task can access
         # even without the need to pass it as parameter - this would be 'default' in such a case

--- a/tasks/infra/prepare-for-rhcl-rc-install-task.yaml
+++ b/tasks/infra/prepare-for-rhcl-rc-install-task.yaml
@@ -50,7 +50,27 @@ spec:
 
         UPDATED_AUTHS_JSON=$(base64 -w0 < updated-auths.json)
 
-        kubectl patch secret pull-secret -n openshift-config --type=merge -p='{"data":{".dockerconfigjson":"'"$UPDATED_AUTHS_JSON"'"}}'
+        patch_status=$(kubectl patch secret pull-secret -n openshift-config --type=merge -p='{"data":{".dockerconfigjson":"'"$UPDATED_AUTHS_JSON"'"}}')
+
+        # wait for global pull secret change to get applied on all nodes
+        if [[ "$patch_status" != *"no change"* ]]; then
+            kubectl wait --for=condition=Updating --timeout=60s mcp/worker
+            kubectl wait --for=condition=Updated --timeout=600s mcp/master
+            kubectl wait --for=condition=Updated --timeout=300s mcp/worker
+            update_finished=$(kubectl get mcp -o json | jq -r '([ .items[] |
+                select(
+                  (.status.conditions[] | select(.type=="Updated").status == "True") and
+                  (.status.conditions[] | select(.type=="Updating").status == "False") and
+                  (.status.conditions[] | select(.type=="Degraded").status == "False")
+                )] | length) == (.items | length)'
+            )
+            if [[ "$update_finished" == "true" ]]; then
+                echo "Global pull secret change has been successfully applied to all nodes"
+            else
+                echo "Global pull secret change has not been applied to all nodes in time"
+                exit 1
+            fi
+        fi
   workspaces:
     - name: shared-workspace
 

--- a/tasks/infra/provision-osd-aws-task.yaml
+++ b/tasks/infra/provision-osd-aws-task.yaml
@@ -11,6 +11,8 @@ spec:
       type: string
     - name: cluster-name
       type: string
+    - name: provision-cluster
+      type: string
   results:
     - name: cluster-id
       description: cluster ID that OCM uses to identify the cluster
@@ -46,7 +48,9 @@ spec:
         export OCM_CONFIG=$(workspaces.shared-workspace.path)/ocm.json
 
         # OSD Cluster Creation Trigger
-        ocm create cluster $(params.cluster-name) $(params.create-cmd-flags) --aws-access-key-id=${AWS_ACCESS_KEY_ID} --aws-secret-access-key=${AWS_SECRET_ACCESS_KEY} --aws-account-id=${AWS_ACCOUNT_ID}
+        if [[ "$(params.provision-cluster)" == "true" ]]; then
+            ocm create cluster $(params.cluster-name) $(params.create-cmd-flags) --aws-access-key-id=${AWS_ACCESS_KEY_ID} --aws-secret-access-key=${AWS_SECRET_ACCESS_KEY} --aws-account-id=${AWS_ACCOUNT_ID}
+        fi
 
         # Include cluster ID in results
         echo -n `ocm get /api/clusters_mgmt/v1/clusters --parameter search="name like '$(params.cluster-name)'" | jq -r '.items[0].id'` | tee $(results.cluster-id.path)

--- a/tasks/infra/provision-osd-gcp-task.yaml
+++ b/tasks/infra/provision-osd-gcp-task.yaml
@@ -11,6 +11,8 @@ spec:
       type: string
     - name: cluster-name
       type: string
+    - name: provision-cluster
+      type: string
   results:
     - name: cluster-id
       description: cluster ID that OCM uses to identify the cluster
@@ -39,7 +41,9 @@ spec:
         echo -n "${SERVICE_ACCOUNT_FILE}" > gcp-osd-ccs-admin-sa-security-key.json
 
         # OSD Cluster Creation Trigger
-        ocm create cluster $(params.cluster-name) $(params.create-cmd-flags) --service-account-file=gcp-osd-ccs-admin-sa-security-key.json
+        if [[ "$(params.provision-cluster)" == "true" ]]; then
+            ocm create cluster $(params.cluster-name) $(params.create-cmd-flags) --service-account-file=gcp-osd-ccs-admin-sa-security-key.json
+        fi
 
         # Explicit removal of the file since it contains sensitive info
         rm gcp-osd-ccs-admin-sa-security-key.json

--- a/tasks/infra/provision-rosa-task.yaml
+++ b/tasks/infra/provision-rosa-task.yaml
@@ -13,6 +13,8 @@ spec:
       type: string
     - name: region
       type: string
+    - name: provision-cluster
+      type: string
   results:
     - name: cluster-id
       description: cluster ID that OCM uses to identify the cluster
@@ -48,7 +50,9 @@ spec:
         export OCM_CONFIG=$(workspaces.shared-workspace.path)/ocm.json
 
         # OSD Cluster Creation Trigger
-        rosa create cluster --cluster-name $(params.cluster-name) --region $(params.region) $(params.create-cmd-flags)
+        if [[ "$(params.provision-cluster)" == "true" ]]; then
+            rosa create cluster --cluster-name $(params.cluster-name) --region $(params.region) $(params.create-cmd-flags)
+        fi
 
         # Include cluster ID in results
         echo -n `ocm get /api/clusters_mgmt/v1/clusters --parameter search="name like '$(params.cluster-name)'" | jq -r '.items[0].id'` | tee $(results.cluster-id.path)

--- a/tasks/provision-install-test/kustomization.yaml
+++ b/tasks/provision-install-test/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 
 resources:
   - parameter-sanity-check-task.yaml
+  - upgrade-to-latest-task.yaml

--- a/tasks/provision-install-test/parameter-sanity-check-task.yaml
+++ b/tasks/provision-install-test/parameter-sanity-check-task.yaml
@@ -19,6 +19,8 @@ spec:
       type: string
     - name: operator-name
       type: string
+    - name: provision-cluster
+      type: string
   results:
     - name: provider-credentials
       description: Credentials for cloud provider
@@ -48,9 +50,11 @@ spec:
         cmd_flags="$(params.create-cmd-flags)"
 
         # fail early if secret already exists
-        if kubectl get secret "$(params.cluster-name)-credentials" -n "$NAMESPACE" &>/dev/null; then
-          echo "Secret '$(params.cluster-name)-credentials' already exists in namespace '$NAMESPACE'. This indicates that a cluster with the same name already exists. Please use a different cluster name, or verify that no such cluster is present and remove the associated secret manually"
-          exit 1
+        if [[ "$(params.provision-cluster)" == "true" ]]; then
+            if kubectl get secret "$(params.cluster-name)-credentials" -n "$NAMESPACE" &>/dev/null; then
+              echo "Secret '$(params.cluster-name)-credentials' already exists in namespace '$NAMESPACE'. This indicates that a cluster with the same name already exists. Please use a different cluster name, or verify that no such cluster is present and remove the associated secret manually"
+              exit 1
+            fi
         fi
 
         # make sure proper defaults are used if provider credentials are not specified

--- a/tasks/provision-install-test/upgrade-to-latest-task.yaml
+++ b/tasks/provision-install-test/upgrade-to-latest-task.yaml
@@ -1,0 +1,41 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: upgrade-to-latest
+spec:
+  description: Upgrade Kuadrant/RHCL to latest version via OLM
+  params:
+    - name: kubeconfig-path
+      type: string
+  steps:
+    - computeResources:
+        limits:
+          cpu: '100m'
+          memory: 128Mi
+      env:
+        - name: KUBECONFIG
+          value: $(params.kubeconfig-path)
+      image: quay.io/kuadrant/testsuite-pipelines-tools:latest
+      imagePullPolicy: Always
+      name: upgrade-to-latest
+      script: |
+        #!/usr/bin/env bash
+        set -evo pipefail
+
+        # Get the namespace of the Subsciption (typically kuadrant-system but it can be different)
+        namespace=$(kubectl get subscription --all-namespaces -o json | jq -r '.items[] | select(.metadata.name == "kuadrant-operator") | .metadata.namespace')
+        if [[ -z "$namespace" ]]; then
+            echo "Subcription 'kuadrant-operator' not found in any namespace."
+            exit 1
+        fi
+
+        # Get the name of InstallPlan and approve it
+        kubectl wait --for=jsonpath={.status.installPlanRef.name} subscription kuadrant-operator -n $namespace --timeout=10s
+        installPlan=$(kubectl get subscription kuadrant-operator -n $namespace -o=jsonpath={.status.installPlanRef.name})
+        kubectl patch installplan $installPlan -n $namespace --type merge --patch '{"spec":{"approved":true}}'
+
+        # Wait for InstallPlan to complete
+        kubectl wait installplan $installPlan -n $namespace --timeout=300s --for=condition=installed=true
+  workspaces:
+    - name: shared-workspace
+


### PR DESCRIPTION
## Overview

Pipeline for upgrade testing.

### What has been done

Small description fix in rosa delete Pipeline.
Added option to skip cluster provisioning in provision-install-test Pipeline, useful if cluster already exists.
Small fix in provision-install-test Pipeline, ocm-login Task has to be done for ROSA too - OCM/HCC is used in subsequent parameter-sanity-check Task to determine ROSA version if the version is not defined explicitly via `create-cmd-params` input parameter.
Reordering steps in helm-instal Task to install Tools first due to Keycloak connection issue that happens if tests are triggered too quickly after Tools installation.
Added wait for global pull secret change to propagate to all nodes.
Added upgrade Pipeline including a new Task to trigger the upgrade to latest version and wait for it to complete.

## Verification Steps
Create a new namespace, create required secrets as described in readme and trigger the pipeline - it can install RHCL v1.0.2 version that pipeline upgrades to v1.1.0. However, much simpler would be to take a look at PipelineRuns in my namespace (trepel2) and inspect the logs.
