### PR TITLE
Hardening of full cycle pipelines

### DIFF
--- a/main/provision-install-test-pipeline.yaml
+++ b/main/provision-install-test-pipeline.yaml
@@ -376,6 +376,18 @@ spec:
       workspaces:
         - name: shared-workspace
           workspace: shared-workspace
+    - name: operator-pod-restart
+      params:
+        - name: kubeconfig-path
+          value: $(tasks.kubectl-login.results.kubeconfig-path)
+      runAfter:
+        - helm-install
+      taskRef:
+        kind: Task
+        name: operator-pod-restart
+      workspaces:
+        - name: shared-workspace
+          workspace: shared-workspace
     - name: run-tests
       params:
         - name: testsuite-image
@@ -395,7 +407,7 @@ spec:
         - name: cluster-credentials
           value: $(tasks.get-osd-credentials.results.credentials-secret)
       runAfter:
-        - helm-install
+        - operator-pod-restart
       taskRef:
         kind: Task
         name: run-tests

--- a/main/provision-upgrade-test-pipeline.yaml
+++ b/main/provision-upgrade-test-pipeline.yaml
@@ -380,6 +380,18 @@ spec:
       workspaces:
         - name: shared-workspace
           workspace: shared-workspace
+    - name: operator-pod-restart
+      params:
+        - name: kubeconfig-path
+          value: $(tasks.kubectl-login.results.kubeconfig-path)
+      runAfter:
+        - helm-install
+      taskRef:
+        kind: Task
+        name: operator-pod-restart
+      workspaces:
+        - name: shared-workspace
+          workspace: shared-workspace
     - name: run-tests-pre-upgrade
       params:
         - name: testsuite-image
@@ -399,7 +411,7 @@ spec:
         - name: cluster-credentials
           value: $(tasks.get-osd-credentials.results.credentials-secret)
       runAfter:
-        - helm-install
+        - operator-pod-restart
       taskRef:
         kind: Task
         name: run-tests

--- a/tasks/infra/prepare-for-rhcl-rc-install-task.yaml
+++ b/tasks/infra/prepare-for-rhcl-rc-install-task.yaml
@@ -55,8 +55,8 @@ spec:
         # wait for global pull secret change to get applied on all nodes
         if [[ "$patch_status" != *"no change"* ]]; then
             kubectl wait --for=condition=Updating --timeout=60s mcp/worker
-            kubectl wait --for=condition=Updated --timeout=600s mcp/master
-            kubectl wait --for=condition=Updated --timeout=300s mcp/worker
+            kubectl wait --for=condition=Updated --timeout=1200s mcp/master
+            kubectl wait --for=condition=Updated --timeout=600s mcp/worker
             update_finished=$(kubectl get mcp -o json | jq -r '([ .items[] |
                 select(
                   (.status.conditions[] | select(.type=="Updated").status == "True") and

--- a/tasks/provision-install-test/kustomization.yaml
+++ b/tasks/provision-install-test/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
   - parameter-sanity-check-task.yaml
   - upgrade-to-latest-task.yaml
+  - operator-pod-restart-task.yaml

--- a/tasks/provision-install-test/operator-pod-restart-task.yaml
+++ b/tasks/provision-install-test/operator-pod-restart-task.yaml
@@ -1,0 +1,46 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: operator-pod-restart
+spec:
+  description: Restart Kuadrant/RHCL operator pod to make sure everything gets reconciled successfully
+  params:
+    - name: kubeconfig-path
+      type: string
+  steps:
+    - computeResources:
+        limits:
+          cpu: '100m'
+          memory: 128Mi
+      env:
+        - name: KUBECONFIG
+          value: $(params.kubeconfig-path)
+      image: quay.io/kuadrant/testsuite-pipelines-tools:latest
+      imagePullPolicy: Always
+      name: operator-pod-restart
+      script: |
+        #!/usr/bin/env bash
+        set -evo pipefail
+
+        # Get the namespace of the Subscription (typically kuadrant-system but it can be different)
+        namespace=$(kubectl get subscription --all-namespaces -o json | jq -r '.items[] | select(.metadata.name == "kuadrant-operator") | .metadata.namespace')
+        if [[ -z "$namespace" ]]; then
+            echo "Subscription 'kuadrant-operator' not found in any namespace."
+            exit 1
+        fi
+
+        # Delete the operator Pod
+        pod_count=$(kubectl get pods -l app=kuadrant -o jsonpath='{.items[*].metadata.name}' -n $namespace | wc -w)
+        if [[ $pod_count -ne 1 ]]; then
+            echo "Expected exactly 1 pod, found $pod_count"
+            exit 1
+        fi
+        pod_name=$(kubectl get pods -l app=kuadrant -o jsonpath='{.items[0].metadata.name}' -n $namespace)
+        kubectl delete pod $pod_name --wait=true --timeout=60s -n $namespace
+
+        # Wait for the new Pod to get up and running
+        pod_name=$(kubectl get pods -l app=kuadrant -o jsonpath='{.items[0].metadata.name}' -n $namespace)
+        kubectl wait --for=condition=Ready pod/$pod_name --timeout=120s -n $namespace
+  workspaces:
+    - name: shared-workspace
+


### PR DESCRIPTION
## Overview

A few improvement to make the pipelines more robust and stable.

### What has been done
Added task to restart kuadrant operator pod after installation - it happens time to time that limitador-/authorino-/dns-oprerator is not fully ready and kuadrant operator sees that and gets stuck. Restart makes kuadrant operator reconcile properly.

Increased timeouts for applying global pull secret change - this can take quite some time sometimes.

## Verification Steps

Run the pipeline (one of the two is enough). Simpler option is to review pipeline run logs in trepe2 ns.