### PR TITLE
Add additional helm tools flags support to deployment pipelines

### DIFF
--- a/deploy/pipeline-nightly-update.yaml
+++ b/deploy/pipeline-nightly-update.yaml
@@ -28,7 +28,11 @@ spec:
     type: string
     default: stable-v26
   - description: Additional flags for helm install command, example '--set=kuadrant.installPlanApproval=Manual --set=kuadrant.startingCSV=kuadrant-operator.v1.2.0'
-    name: helm-install-flags
+    name: additional-helm-flags
+    type: string
+    default: ' '
+  - description: Additional flags for tools helm, example '--set=tools.keycloak.keycloakProvider=deployment --set=tools.valkey.enable=false'"
+    name: additional-helm-tools-flags
     type: string
     default: ' '
   tasks:
@@ -88,8 +92,10 @@ spec:
         value: $(params.operator-name)
       - name: kubeconfig-path
         value: $(tasks.kubectl-login.results.kubeconfig-path)
-      - name: helm-install-flags
-        value: $(params.helm-install-flags)
+      - name: additional-helm-flags
+        value: $(params.additional-helm-flags)
+      - name: additional-helm-tools-flags
+        value: $(params.additional-helm-tools-flags)
     runAfter:
     - helm-uninstall
     taskRef:

--- a/deploy/pipeline.yaml
+++ b/deploy/pipeline.yaml
@@ -36,7 +36,11 @@ spec:
     type: string
     default: stable-v26
   - description: Additional flags for helm install command, example '--set=kuadrant.installPlanApproval=Manual --set=kuadrant.startingCSV=kuadrant-operator.v1.2.0'
-    name: helm-install-flags
+    name: additional-helm-flags
+    type: string
+    default: ' '
+  - description: Additional flags for tools helm, example '--set=tools.keycloak.keycloakProvider=deployment --set=tools.valkey.enable=false'"
+    name: additional-helm-tools-flags
     type: string
     default: ' '
   tasks:
@@ -90,8 +94,10 @@ spec:
         value: $(params.operator-name)
       - name: kubeconfig-path
         value: $(tasks.kubectl-login.results.kubeconfig-path)
-      - name: helm-install-flags
-        value: $(params.helm-install-flags)
+      - name: additional-helm-flags
+        value: $(params.additional-helm-flags)
+      - name: additional-helm-tools-flags
+        value: $(params.additional-helm-tools-flags)
     runAfter:
     - helm-uninstall
     taskRef:

--- a/tasks/deploy/helm-install-task.yaml
+++ b/tasks/deploy/helm-install-task.yaml
@@ -26,13 +26,17 @@ spec:
       name: operator-name
       type: string
     - description: Additional flags for helm install command, example '--set=kuadrant.installPlanApproval=Manual --set=kuadrant.startingCSV=kuadrant-operator.v1.2.0'"
-      name: helm-install-flags
+      name: additional-helm-flags
+      type: string
+    - description: Additional flags for tools helm, example '--set=tools.keycloak.keycloakProvider=deployment --set=tools.valkey.enable=false'"
+      name: additional-helm-tools-flags
       type: string
   steps:
   - name: helm-install-tools-operators
     script: >
       helm install -n=default
       --repo https://kuadrant.io/helm-charts-olm
+      $(params.additional-helm-tools-flags)
       --wait --debug
       tools-operators
       tools-operators
@@ -45,6 +49,7 @@ spec:
     script: >
       helm install -n=default
       --repo https://kuadrant.io/helm-charts-olm
+      $(params.additional-helm-tools-flags)
       --wait --debug --timeout=10m0s
       tools-instances
       tools-instances
@@ -65,7 +70,7 @@ spec:
       --set=gatewayAPI.version="$(params.gateway-crd)"
       --set=tools.keycloak.operator.channel="$(params.keycloak-channel)"
       --set=tools.enabled=true
-      $(params.helm-install-flags)
+      $(params.additional-helm-flags)
       --wait --debug
       kuadrant-operators
       kuadrant-operators
@@ -89,7 +94,7 @@ spec:
       --set=gatewayAPI.version="$(params.gateway-crd)"
       --set=tools.keycloak.operator.channel="$(params.keycloak-channel)"
       --set=tools.enabled=true
-      $(params.helm-install-flags)
+      $(params.additional-helm-flags)
       --wait --debug
       kuadrant-instances
       kuadrant-instances


### PR DESCRIPTION
## Summary

- Adds support for separate `additional-helm-tools-flags` parameter in deployment pipelines
- Updates both helm deploy and helm update pipelines consistently

## Verification Steps

Eye review or check the successful pipelinerun named kuadrant-nightly-update-pipeline-wfz7z2

🤖 Generated with [Claude Code](https://claude.ai/code)