### PR TITLE
Replace space defaults with empty strings and increase MCP timeouts

### DIFF
--- a/deploy/pipeline-nightly-update.yaml
+++ b/deploy/pipeline-nightly-update.yaml
@@ -30,15 +30,15 @@ spec:
   - description: Extensions binary image
     name: extensions-binary-image
     type: string
-    default: ' '
+    default: ""
   - description: Additional flags for helm install command, example '--set=kuadrant.installPlanApproval=Manual --set=kuadrant.startingCSV=kuadrant-operator.v1.2.0'
     name: additional-helm-flags
     type: string
-    default: ' '
+    default: ""
   - description: Additional flags for tools helm, example '--set=tools.keycloak.keycloakProvider=deployment --set=tools.valkey.enable=false'"
     name: additional-helm-tools-flags
     type: string
-    default: ' '
+    default: ""
   tasks:
   - name: nightly-image-date
     taskRef:

--- a/deploy/pipeline.yaml
+++ b/deploy/pipeline.yaml
@@ -38,15 +38,15 @@ spec:
   - description: Extensions binary image
     name: extensions-binary-image
     type: string
-    default: ' '
+    default: ""
   - description: Additional flags for helm install command, example '--set=kuadrant.installPlanApproval=Manual --set=kuadrant.startingCSV=kuadrant-operator.v1.2.0'
     name: additional-helm-flags
     type: string
-    default: ' '
+    default: ""
   - description: Additional flags for tools helm, example '--set=tools.keycloak.keycloakProvider=deployment --set=tools.valkey.enable=false'"
     name: additional-helm-tools-flags
     type: string
-    default: ' '
+    default: ""
   tasks:
   - name: check-image-existence
     params:

--- a/main/aro-provision-install-test-pipeline.yaml
+++ b/main/aro-provision-install-test-pipeline.yaml
@@ -46,7 +46,7 @@ spec:
       description: Istio provider (ossm3, ocp), use ossm3 for OCP v4.18 and before
       name: istio-provider
       type: string
-    - default: ' '
+    - default: ""
       description: GatewayAPI CRD version. v1.0.0, v1.1.0, v1.2.1, v1.3.0 available; Leave empty if installing on OCP v4.19+
       name: gateway-crd
       type: string
@@ -54,15 +54,15 @@ spec:
       description: Keycloak subscription channel
       name: keycloak-channel
       type: string
-    - default: ' '
+    - default: ""
       description: Extensions binary image
       name: extensions-binary-image
       type: string
-    - default: ' '
+    - default: ""
       description: Additional flags for helm install command, example '--set=kuadrant.installPlanApproval=Manual --set=kuadrant.startingCSV=kuadrant-operator.v1.2.0'
       name: additional-helm-flags
       type: string
-    - default: ' '
+    - default: ""
       description: Additional flags for tools helm, example '--set=tools.keycloak.keycloakProvider=deployment --set=tools.valkey.enable=false'"
       name: additional-helm-tools-flags
       type: string
@@ -79,7 +79,7 @@ spec:
       description: Makefile target for tests
       name: make-target
       type: string
-    - default: ' '
+    - default: ""
       description: Pytest flags to use with Make (flags="${pytest-flags}" make kuadrant)
       name: pytest-flags
       type: string
@@ -87,7 +87,7 @@ spec:
       description: Config Map with settings for the testsuite
       name: settings-cm
       type: string
-    - default: ' '
+    - default: ""
       description: Additional env for testsuite container separated with spaces (e.g. KUADRANT_CONTROL_PLANE__provider_secret=gcp-credentials KUADRANT_KEYCLOAK__url="https://my-sso.net")
       name: additional-env
       type: string
@@ -96,7 +96,7 @@ spec:
       description: Prefix of the launch name saved in report portal (nightly, username, manual, etc.). In case of release candidate testing use kuadrant-v<version>, rhcl-v<version>, or authorino-v<version>
       name: launch-name
       type: string
-    - default: ' '
+    - default: ""
       description: Optional launch description for Report Portal
       name: launch-description
       type: string

--- a/main/provision-install-test-pipeline.yaml
+++ b/main/provision-install-test-pipeline.yaml
@@ -13,7 +13,7 @@ spec:
       description: Cluster type (osd-aws, osd-gcp, rosa)
       name: cluster-type
       type: string
-    - default: ' '
+    - default: ""
       description: Cloud Provider credentials, leave empty to use defaults
       name: provider-credentials
       type: string
@@ -33,7 +33,7 @@ spec:
       description: Cluster name
       name: cluster-name
       type: string
-    - default: ' '
+    - default: ""
       description: Cluster creation flags. Leave empty to use defaults (they depend on Cloud Provider)
       name: create-cmd-flags
       type: string
@@ -54,7 +54,7 @@ spec:
       description: Istio provider (ossm3, ocp), use ossm3 for OCP v4.18 and before
       name: istio-provider
       type: string
-    - default: ' '
+    - default: ""
       description: GatewayAPI CRD version. v1.0.0, v1.1.0, v1.2.1, v1.3.0 available; Leave empty if installing on OCP v4.19+
       name: gateway-crd
       type: string
@@ -62,15 +62,15 @@ spec:
       description: Keycloak subscription channel
       name: keycloak-channel
       type: string
-    - default: ' '
+    - default: ""
       description: Extensions binary image
       name: extensions-binary-image
       type: string
-    - default: ' '
+    - default: ""
       description: Additional flags for helm install command, example '--set=kuadrant.installPlanApproval=Manual --set=kuadrant.startingCSV=kuadrant-operator.v1.2.0'
       name: additional-helm-flags
       type: string
-    - default: ' '
+    - default: ""
       description: Additional flags for tools helm, example '--set=tools.keycloak.keycloakProvider=deployment --set=tools.valkey.enable=false'"
       name: additional-helm-tools-flags
       type: string
@@ -87,7 +87,7 @@ spec:
       description: Makefile target for tests
       name: make-target
       type: string
-    - default: ' '
+    - default: ""
       description: Pytest flags to use with Make (flags="${pytest-flags}" make kuadrant)
       name: pytest-flags
       type: string
@@ -95,7 +95,7 @@ spec:
       description: Config Map with settings for the testsuite
       name: settings-cm
       type: string
-    - default: ' '
+    - default: ""
       description: Additional env for testsuite container separated with spaces (e.g. KUADRANT_CONTROL_PLANE__provider_secret=gcp-credentials KUADRANT_KEYCLOAK__url="https://my-sso.net")
       name: additional-env
       type: string
@@ -104,7 +104,7 @@ spec:
       description: Prefix of the launch name saved in report portal (nightly, username, manual, etc.). In case of release candidate testing use kuadrant-v<version>, rhcl-v<version>, or authorino-v<version>
       name: launch-name
       type: string
-    - default: ' '
+    - default: ""
       description: Optional launch description for Report Portal
       name: launch-description
       type: string

--- a/main/provision-upgrade-test-pipeline.yaml
+++ b/main/provision-upgrade-test-pipeline.yaml
@@ -13,7 +13,7 @@ spec:
       description: Cluster type (osd-aws, osd-gcp, rosa)
       name: cluster-type
       type: string
-    - default: ' '
+    - default: ""
       description: Cloud Provider credentials, leave empty to use defaults
       name: provider-credentials
       type: string
@@ -33,12 +33,12 @@ spec:
       description: Cluster name
       name: cluster-name
       type: string
-    - default: ' '
+    - default: ""
       description: Cluster creation flags. Leave empty to use defaults (they depend on Cloud Provider)
       name: create-cmd-flags
       type: string
 # Kuadrant/RHCL installation/upgrade related parameters
-    - default: ' '
+    - default: ""
       description: Kuadrant/RHCL index image, must contain proper bundle chain for upgrade
       name: index-image
       type: string
@@ -54,7 +54,7 @@ spec:
       description: Istio provider (ossm3, ocp), use ossm3 for OCP v4.18 and before
       name: istio-provider
       type: string
-    - default: ' '
+    - default: ""
       description: GatewayAPI CRD version. v1.0.0, v1.1.0, v1.2.1, v1.3.0 available; Leave empty if installing on OCP v4.19+
       name: gateway-crd
       type: string
@@ -62,15 +62,15 @@ spec:
       description: Keycloak subscription channel
       name: keycloak-channel
       type: string
-    - default: ' '
+    - default: ""
       description: Extensions binary image
       name: extensions-binary-image
       type: string
-    - default: ' '
+    - default: ""
       description: Additional flags for helm install command, example '--set=kuadrant.installPlanApproval=Manual --set=kuadrant.startingCSV=kuadrant-operator.v1.2.0'
       name: additional-helm-flags
       type: string
-    - default: ' '
+    - default: ""
       description: Additional flags for tools helm, example '--set=tools.keycloak.keycloakProvider=deployment --set=tools.valkey.enable=false'"
       name: additional-helm-tools-flags
       type: string
@@ -91,7 +91,7 @@ spec:
       description: Makefile target for post-upgrade tests
       name: post-upgrade-make-target
       type: string
-    - default: ' '
+    - default: ""
       description: Pytest flags to use with Make (flags="${pytest-flags}" make kuadrant)
       name: pytest-flags
       type: string
@@ -99,7 +99,7 @@ spec:
       description: Config Map with settings for the testsuite
       name: settings-cm
       type: string
-    - default: ' '
+    - default: ""
       description: Additional env for testsuite container separated with spaces (e.g. KUADRANT_CONTROL_PLANE__provider_secret=gcp-credentials KUADRANT_KEYCLOAK__url="https://my-sso.net")
       name: additional-env
       type: string
@@ -108,7 +108,7 @@ spec:
       description: Prefix of the launch name saved in report portal (nightly, username, manual, etc.). In case of release candidate testing use kuadrant-v<version>, rhcl-v<version>, or authorino-v<version>
       name: launch-name
       type: string
-    - default: ' '
+    - default: ""
       description: Optional launch description for Report Portal
       name: launch-description
       type: string

--- a/tasks/infra/prepare-for-rhcl-rc-install-task.yaml
+++ b/tasks/infra/prepare-for-rhcl-rc-install-task.yaml
@@ -54,9 +54,9 @@ spec:
 
         # wait for global pull secret change to get applied on all nodes
         if [[ "$patch_status" != *"no change"* ]]; then
-            kubectl wait --for=condition=Updating --timeout=60s mcp/worker
-            kubectl wait --for=condition=Updated --timeout=1200s mcp/master
-            kubectl wait --for=condition=Updated --timeout=600s mcp/worker
+            kubectl wait --for=condition=Updating --timeout=120s mcp/worker
+            kubectl wait --for=condition=Updated --timeout=1800s mcp/master
+            kubectl wait --for=condition=Updated --timeout=1200s mcp/worker
             update_finished=$(kubectl get mcp -o json | jq -r '([ .items[] |
                 select(
                   (.status.conditions[] | select(.type=="Updated").status == "True") and


### PR DESCRIPTION
## Overview
Replace space defaults with empty strings and increase MCP timeouts.

Using empty string instead of single space char is much nicer and avoid issues in contexts where single space matters (e.g. single space can be evaluated to true rather that false etc). It is also consistent with some other pipelines where we using empty string already:
* https://github.com/Kuadrant/testsuite-pipelines/blob/main/main/pipeline.yaml#L26-L42
* https://github.com/Kuadrant/testsuite-pipelines/blob/main/nightly/pipeline.yaml#L45
* https://github.com/Kuadrant/testsuite-pipelines/blob/main/release/pipeline.yaml#L26-L45
* https://github.com/Kuadrant/testsuite-pipelines/blob/main/release/pipeline.yaml#L26-L45

I also increased timeout for global pull secret change to get applied across all the nodes on the cluster. I was still experiencing timeouts on AWS/GCP/ROSA/ARO clusters time to time. Not sure why it sometimes takes that long but it is not Kuadrant related.

### Verification Steps

Eye review - this is sufficient for the timeout change.

You can also take a look at pipeline run in trepel ns. I created a pipelines there out of this PR and created one pipeline run there with most of the input parameters that default to empty string were omitted. It worked!

If you want to validate yourself, trigger all the affected pipelines, do not specify input parameters that default to empty string to verify that
1) the parameters are still optional
2) using empty string rather than single space char causes no issue



