### PR TITLE
Remove workspace from delete ARO task

### DIFF
--- a/pipelines/test/aro/pipeline.yaml
+++ b/pipelines/test/aro/pipeline.yaml
@@ -330,8 +330,6 @@ spec:
       taskRef:
         kind: Task
         name: delete-aro
-      workspaces:
-        - name: shared-workspace
     - name: cluster-secret-cleanup
       when:
         - input: $(params.cleanup)


### PR DESCRIPTION
## Overview

Remove workspace from delete ARO task. This task does not require workspace at all. It is used in another pipeline without the workspace:
https://github.com/Kuadrant/testsuite-pipelines/blob/main/pipelines/infra/delete-aro/pipeline.yaml#L24-L34

### Verification Steps
Eye review, this change is simple enough, it is used like this in another pipeline, and I already applied this to kua-hub so you can take a look at
rhcl-install-aro-cleanup PipelineRun to see what issue this causes
rhcl-install-aro-cleanup-4 PipelineRun to see that this change indeed fixed the issue