### PR TITLE
Update nightly pipelineRef name

### DIFF
--- a/pipelines/test/nightly/eventlistener.yaml
+++ b/pipelines/test/nightly/eventlistener.yaml
@@ -43,10 +43,10 @@ spec:
             - apiVersion: tekton.dev/v1beta1
               kind: PipelineRun
               metadata:
-                generateName: nightly-$(tt.params.make-target)-
+                generateName: test-nightly-$(tt.params.make-target)-
               spec:
                 pipelineRef:
-                  name: nightly-pipeline
+                  name: test-nightly
                 timeouts:
                   pipeline: 2h0m0s
                 params:


### PR DESCRIPTION
The nightly testsuite EventListener was still referencing the old `nightly-pipeline` name, causing the runs to fail.

This PR updates the EventListener to reference the correct `test-nightly` pipeline so that the nightly runs are created and executed successfully again.
