### PR TITLE
Remove ICSP from ARO/ROSA/OSD clusters

### DIFF
--- a/tasks/infra/prepare-for-rhcl-rc-install.yaml
+++ b/tasks/infra/prepare-for-rhcl-rc-install.yaml
@@ -27,22 +27,6 @@ spec:
         #!/usr/bin/env bash
         set -evo pipefail
 
-        # Creates ICSP that allow to mirroring to brew
-        kubectl apply -f -<<EOF
-            apiVersion: operator.openshift.io/v1alpha1
-            kind: ImageContentSourcePolicy
-            metadata:
-              name: errata-from-brew
-            spec:
-              repositoryDigestMirrors:
-              - mirrors:
-                - brew.registry.redhat.io/rh-osbs
-                source: registry-proxy.engineering.redhat.com/rh-osbs
-              - mirrors:
-                  - brew.registry.redhat.io/rhcl-1
-                source: registry.redhat.io/rhcl-1
-        EOF
-
         # update global pull secret
         kubectl get secret/pull-secret -n openshift-config -o jsonpath='{.data.\.dockerconfigjson}' | base64 -d > current-auths.json
 


### PR DESCRIPTION
## Overview

Since move to Konflux neither registry-proxy nor brew registries are used. Thus ICSP is no longer needed.

### Verification Steps

Eye review should suffice. More thorough verification (I did that though) would be to install RHCL from `quay.io/trepel/index-from-errata:rhcl-111-multiarch` (it is an index image containing Konflux built bundles for all RHCL-related operators and operands) on a cluster without the ICSP but I don't think it's necessary given how simple the changes in this PR are.