### PR TITLE
Do useful product configuration updates after installation

### DIFF
--- a/pipelines/test/aro/pipeline.yaml
+++ b/pipelines/test/aro/pipeline.yaml
@@ -232,6 +232,18 @@ spec:
       workspaces:
         - name: shared-workspace
           workspace: shared-workspace
+    - name: do-custom-updates
+      params:
+        - name: kubeconfig-path
+          value: $(tasks.kubectl-login.results.kubeconfig-path)
+      runAfter:
+        - operator-pod-restart
+      taskRef:
+        kind: Task
+        name: do-custom-updates
+      workspaces:
+        - name: shared-workspace
+          workspace: shared-workspace
     - name: run-tests
       params:
         - name: testsuite-image
@@ -251,7 +263,7 @@ spec:
         - name: cluster-credentials
           value: $(tasks.provision-aro.results.credentials-secret)
       runAfter:
-        - operator-pod-restart
+        - do-custom-updates
       taskRef:
         kind: Task
         name: run-tests

--- a/pipelines/test/osd-upgrade/pipeline.yaml
+++ b/pipelines/test/osd-upgrade/pipeline.yaml
@@ -396,6 +396,18 @@ spec:
       workspaces:
         - name: shared-workspace
           workspace: shared-workspace
+    - name: do-custom-updates
+      params:
+        - name: kubeconfig-path
+          value: $(tasks.kubectl-login.results.kubeconfig-path)
+      runAfter:
+        - operator-pod-restart
+      taskRef:
+        kind: Task
+        name: do-custom-updates
+      workspaces:
+        - name: shared-workspace
+          workspace: shared-workspace
     - name: run-tests-pre-upgrade
       params:
         - name: testsuite-image
@@ -415,7 +427,7 @@ spec:
         - name: cluster-credentials
           value: $(tasks.get-osd-credentials.results.credentials-secret)
       runAfter:
-        - operator-pod-restart
+        - do-custom-updates
       taskRef:
         kind: Task
         name: run-tests

--- a/pipelines/test/osd/pipeline.yaml
+++ b/pipelines/test/osd/pipeline.yaml
@@ -392,6 +392,18 @@ spec:
       workspaces:
         - name: shared-workspace
           workspace: shared-workspace
+    - name: do-custom-updates
+      params:
+        - name: kubeconfig-path
+          value: $(tasks.kubectl-login.results.kubeconfig-path)
+      runAfter:
+        - operator-pod-restart
+      taskRef:
+        kind: Task
+        name: do-custom-updates
+      workspaces:
+        - name: shared-workspace
+          workspace: shared-workspace
     - name: run-tests
       params:
         - name: testsuite-image
@@ -411,7 +423,7 @@ spec:
         - name: cluster-credentials
           value: $(tasks.get-osd-credentials.results.credentials-secret)
       runAfter:
-        - operator-pod-restart
+        - do-custom-updates
       taskRef:
         kind: Task
         name: run-tests

--- a/tasks/infra/do-custom-updates.yaml
+++ b/tasks/infra/do-custom-updates.yaml
@@ -1,0 +1,37 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: do-custom-updates
+spec:
+  description: 'Allow for patching custom resources and other custom updates'
+  params:
+    - name: kubeconfig-path
+      type: string
+  steps:
+    - name: do-custom-updates
+      computeResources:
+        limits:
+          cpu: '100m'
+          memory: 64Mi
+      image: quay.io/kuadrant/testsuite-pipelines-tools:latest
+      imagePullPolicy: Always
+      env:
+        - name: KUBECONFIG
+          value: $(params.kubeconfig-path)
+      script: |
+        #!/bin/bash
+        set -euo pipefail
+
+        # enable user workload monitoring
+        kubectl apply -n openshift-monitoring -f -<<EOF
+            apiVersion: v1
+            kind: ConfigMap
+            metadata:
+                name: cluster-monitoring-config
+                namespace: openshift-monitoring
+            data:
+                config.yaml: |
+                    enableUserWorkload: true
+        EOF
+  workspaces:
+    - name: shared-workspace

--- a/tasks/infra/kustomization.yaml
+++ b/tasks/infra/kustomization.yaml
@@ -23,3 +23,4 @@ resources:
   - wait-till-osd-is-deleted.yaml
   - wait-till-osd-is-ready.yaml
   - helm-uninstall.yaml
+  - do-custom-updates.yaml


### PR DESCRIPTION
## Overview

We need to set up workload monitoring explicitly on clusters for RHCL. It is just this atm since we decided that helm-charts-olm repository is a better home for RHCL configuration updates.

### Verification Steps
Eye review. The Task is already applied so you can take a look at recent TaskRuns. Just note that the Task there also contains some other RHCL configuration updates since we haven't implemented them in helm-charts-olm yet, PR exists though: https://github.com/Kuadrant/helm-charts-olm/pull/58