### PR TITLE
Add option to pause pipeline after the upgrade

### DIFF
--- a/pipelines/test/osd-upgrade/pipeline.yaml
+++ b/pipelines/test/osd-upgrade/pipeline.yaml
@@ -421,7 +421,7 @@ spec:
         name: run-tests
       workspaces:
         - name: shared-workspace
-    - name: pause-pipeline
+    - name: pause-pipeline-pre-upgrade
       runAfter:
         - run-tests-pre-upgrade
       taskRef:
@@ -432,12 +432,18 @@ spec:
         - name: kubeconfig-path
           value: $(tasks.kubectl-login.results.kubeconfig-path)
       runAfter:
-        - pause-pipeline
+        - pause-pipeline-pre-upgrade
       taskRef:
         kind: Task
         name: upgrade-to-latest
       workspaces:
         - name: shared-workspace
+    - name: pause-pipeline-post-upgrade
+      runAfter:
+        - upgrade-to-latest
+      taskRef:
+        kind: Task
+        name: pause-pipeline
     - name: run-tests-post-upgrade
       params:
         - name: testsuite-image
@@ -457,7 +463,7 @@ spec:
         - name: cluster-credentials
           value: $(tasks.get-osd-credentials.results.credentials-secret)
       runAfter:
-        - upgrade-to-latest
+        - pause-pipeline-post-upgrade
       taskRef:
         kind: Task
         name: run-tests


### PR DESCRIPTION
## Overview

There are use cases when we need to pause the pipeline after the upgrade too like patching Subscription to used different wasmshim image.


### Verification Steps
Run the pipeline, make sure the configmap exists first:
`kubectl create configmap pause-pipeline --from-literal=pause=true -n $PIPELINE_NAMESPACE`

Given how simple the change is I would say eye review will suffice.