### PR TITLE
Remove explicit keycloak version parameter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,7 +150,6 @@ Manual builds should only be performed in emergencies. See README.md for manual 
 - `operator-name` - Operator name (`kuadrant-operator` or `rhcl-operator`)
 - `istio-provider` - Istio provider (`ossm3` recommended, `ocp` for OCP 4.19+ Gateway API-managed Istio)
 - `gateway-crd` - GatewayAPI CRD version (e.g., `v1.2.1`, `v1.3.0`, `v1.4.0`, empty for OCP 4.19+)
-- `keycloak-channel` - Keycloak subscription channel (default: `stable-v26`)
 - `additional-helm-flags` - Extra helm flags for operators/instances (e.g., `--set=kuadrant.installPlanApproval=Manual`)
 - `additional-helm-tools-flags` - Extra helm flags for tools (e.g., `--set=tools.keycloak.keycloakProvider=deployment`)
 

--- a/pipelines/deploy/kuadrant-nightly-update/pipeline.yaml
+++ b/pipelines/deploy/kuadrant-nightly-update/pipeline.yaml
@@ -23,10 +23,6 @@ spec:
     name: gateway-crd
     type: string
     default: ""
-  - description: Keycloak subscription channel
-    name: keycloak-channel
-    type: string
-    default: stable-v26
   - description: Additional flags for helm install command, example '--set=kuadrant.installPlanApproval=Manual --set=kuadrant.startingCSV=kuadrant-operator.v1.2.0'
     name: additional-helm-flags
     type: string
@@ -74,8 +70,6 @@ spec:
         value: $(params.istio-provider)
       - name: gateway-crd
         value: $(params.gateway-crd)
-      - name: keycloak-channel
-        value: $(params.keycloak-channel)
       - name: operator-name
         value: $(params.operator-name)
       - name: kubeconfig-path

--- a/pipelines/deploy/kuadrant-testsuite/pipeline.yaml
+++ b/pipelines/deploy/kuadrant-testsuite/pipeline.yaml
@@ -31,10 +31,6 @@ spec:
     name: gateway-crd
     type: string
     default: ""
-  - description: Keycloak subscription channel
-    name: keycloak-channel
-    type: string
-    default: stable-v26
   - description: Additional flags for helm install command, example '--set=kuadrant.installPlanApproval=Manual --set=kuadrant.startingCSV=kuadrant-operator.v1.2.0'
     name: additional-helm-flags
     type: string
@@ -82,8 +78,6 @@ spec:
         value: $(params.istio-provider)
       - name: gateway-crd
         value: $(params.gateway-crd)
-      - name: keycloak-channel
-        value: $(params.keycloak-channel)
       - name: operator-name
         value: $(params.operator-name)
       - name: kubeconfig-path

--- a/pipelines/test/aro/pipeline.yaml
+++ b/pipelines/test/aro/pipeline.yaml
@@ -50,10 +50,6 @@ spec:
       description: GatewayAPI CRD version. [v1.2.1, v1.3.0, v1.4.0] available; leave empty if installing on Openshift 4.19+.
       name: gateway-crd
       type: string
-    - default: stable-v26
-      description: Keycloak subscription channel
-      name: keycloak-channel
-      type: string
     - default: ""
       description: Additional flags for helm install command, example '--set=kuadrant.installPlanApproval=Manual --set=kuadrant.startingCSV=kuadrant-operator.v1.2.0'
       name: additional-helm-flags
@@ -204,8 +200,6 @@ spec:
           value: $(tasks.kubectl-login.results.kubeconfig-path)
         - name: gateway-crd
           value: $(params.gateway-crd)
-        - name: keycloak-channel
-          value: $(params.keycloak-channel)
         - name: additional-helm-flags
           value: $(params.additional-helm-flags)
         - name: additional-helm-tools-flags

--- a/pipelines/test/ocp/aws/pipeline.yaml
+++ b/pipelines/test/ocp/aws/pipeline.yaml
@@ -43,10 +43,6 @@ spec:
       description: GatewayAPI CRD version. [v1.2.1, v1.3.0, v1.4.0] available; leave empty if installing on Openshift 4.19+.
       name: gateway-crd
       type: string
-    - default: stable-v26
-      description: Keycloak subscription channel
-      name: keycloak-channel
-      type: string
     - default: ""
       description: Additional flags for helm install command, example '--set=kuadrant.installPlanApproval=Manual --set=kuadrant.startingCSV=kuadrant-operator.v1.2.0'
       name: additional-helm-flags
@@ -141,8 +137,6 @@ spec:
           value: $(tasks.provision-ocp-aws.results.kubeconfig-path)
         - name: gateway-crd
           value: $(params.gateway-crd)
-        - name: keycloak-channel
-          value: $(params.keycloak-channel)
         - name: additional-helm-flags
           value: $(params.additional-helm-flags)
         - name: additional-helm-tools-flags

--- a/pipelines/test/osd-upgrade/pipeline.yaml
+++ b/pipelines/test/osd-upgrade/pipeline.yaml
@@ -62,10 +62,6 @@ spec:
       description: GatewayAPI CRD version. [v1.2.1, v1.3.0, v1.4.0] available; leave empty if installing on Openshift 4.19+.
       name: gateway-crd
       type: string
-    - default: stable-v26
-      description: Keycloak subscription channel
-      name: keycloak-channel
-      type: string
     - default: ""
       description: Additional flags for helm install command, example '--set=kuadrant.installPlanApproval=Manual --set=kuadrant.startingCSV=kuadrant-operator.v1.2.0'
       name: additional-helm-flags
@@ -368,8 +364,6 @@ spec:
           value: $(tasks.kubectl-login.results.kubeconfig-path)
         - name: gateway-crd
           value: $(params.gateway-crd)
-        - name: keycloak-channel
-          value: $(params.keycloak-channel)
         - name: additional-helm-flags
           value: $(params.additional-helm-flags)
         - name: additional-helm-tools-flags

--- a/pipelines/test/osd/pipeline.yaml
+++ b/pipelines/test/osd/pipeline.yaml
@@ -62,10 +62,6 @@ spec:
       description: GatewayAPI CRD version. [v1.2.1, v1.3.0, v1.4.0] available; leave empty if installing on Openshift 4.19+.
       name: gateway-crd
       type: string
-    - default: stable-v26
-      description: Keycloak subscription channel
-      name: keycloak-channel
-      type: string
     - default: ""
       description: Additional flags for helm install command, example '--set=kuadrant.installPlanApproval=Manual --set=kuadrant.startingCSV=kuadrant-operator.v1.2.0'
       name: additional-helm-flags
@@ -364,8 +360,6 @@ spec:
           value: $(tasks.kubectl-login.results.kubeconfig-path)
         - name: gateway-crd
           value: $(params.gateway-crd)
-        - name: keycloak-channel
-          value: $(params.keycloak-channel)
         - name: additional-helm-flags
           value: $(params.additional-helm-flags)
         - name: additional-helm-tools-flags

--- a/tasks/deploy/helm-deploy.yaml
+++ b/tasks/deploy/helm-deploy.yaml
@@ -16,9 +16,6 @@ spec:
     - description: GatewayAPI CRD version. [v1.2.1, v1.3.0, v1.4.0] available; leave empty if installing on Openshift 4.19+.
       name: gateway-crd
       type: string
-    - description: Keycloak subscription channel
-      name: keycloak-channel
-      type: string
     - description: Path to workspace kubeconfig
       name: kubeconfig-path
       type: string
@@ -164,7 +161,6 @@ spec:
       --set=kuadrant.operatorName="$(params.operator-name)"
       --set=istio.istioProvider="$(params.istio-provider)"
       --set=gatewayAPI.version="$(params.gateway-crd)"
-      --set=tools.keycloak.operator.channel="$(params.keycloak-channel)"
       --set=tools.enabled=true
       $(params.additional-helm-flags)
       --wait --debug
@@ -188,7 +184,6 @@ spec:
       --set=kuadrant.operatorName="$(params.operator-name)"
       --set=istio.istioProvider="$(params.istio-provider)"
       --set=gatewayAPI.version="$(params.gateway-crd)"
-      --set=tools.keycloak.operator.channel="$(params.keycloak-channel)"
       --set=tools.enabled=true
       $(params.additional-helm-flags)
       --wait --debug


### PR DESCRIPTION
This was added as a quick fix due to hard coded keycloak version. Now it can be set with `additional-helm-flags` so to reduce number of non-needed parameters I opt to remove it.