### PR TITLE
chore: update default values for istio-provider and gateway-crd

### DIFF
--- a/pipelines/deploy/kuadrant-nightly-update/pipeline.yaml
+++ b/pipelines/deploy/kuadrant-nightly-update/pipeline.yaml
@@ -11,18 +11,18 @@ spec:
     name: cluster-credentials
     type: string
     default: openshift-pipelines-credentials
-  - description: A 'ossm3' for Openshift Service mesh v3, 'ocp' for installing on Openshift 4.19+
+  - description: Istio provider (ossm3, ocp); 'ossm3' (recommended for all Openshift versions), 'ocp' for installing Istio managed by Gateway API on OCP v4.19+ (not recommended: mTLS is not supported).
     name: istio-provider
     type: string
-    default: ocp
+    default: ossm3
   - description: Kuadrant operator name. 'kuadrant-operator' or 'rhcl-operator'
     name: operator-name
     type: string
     default: kuadrant-operator
-  - description: GatewayAPI CRD version. [v1.2.1, v1.3.0, v1.4.0] available; Installation skipped if 'ocp' istio-provider is used
+  - description: GatewayAPI CRD version. [v1.2.1, v1.3.0, v1.4.0] available; leave empty if installing on Openshift 4.19+.
     name: gateway-crd
     type: string
-    default: v1.4.0
+    default: ""
   - description: Keycloak subscription channel
     name: keycloak-channel
     type: string

--- a/pipelines/deploy/kuadrant-testsuite/pipeline.yaml
+++ b/pipelines/deploy/kuadrant-testsuite/pipeline.yaml
@@ -14,7 +14,7 @@ spec:
   - description: Kuadrant image url
     name: index-image
     type: string
-    default: quay.io/kuadrant/kuadrant-operator-catalog:v1.2.0
+    default: quay.io/kuadrant/kuadrant-operator-catalog:v1.3.1
   - description: Kuadrant image channel. Can be 'preview' for nightlies and 'stable' for releases
     name: channel
     type: string
@@ -23,14 +23,14 @@ spec:
     name: operator-name
     type: string
     default: kuadrant-operator
-  - description: A 'ossm3' for Openshift Service mesh v3, 'ocp' for installing on Openshift 4.19+
+  - description: Istio provider (ossm3, ocp); 'ossm3' (recommended for all Openshift versions), 'ocp' for installing Istio managed by Gateway API on OCP v4.19+ (not recommended: mTLS is not supported).
     name: istio-provider
     type: string
-    default: ocp
-  - description: GatewayAPI CRD version. [v1.2.1, v1.3.0, v1.4.0] available; Installation skipped if 'ocp' istio-provider is used
+    default: ossm3
+  - description: GatewayAPI CRD version. [v1.2.1, v1.3.0, v1.4.0] available; leave empty if installing on Openshift 4.19+.
     name: gateway-crd
     type: string
-    default: v1.4.0
+    default: ""
   - description: Keycloak subscription channel
     name: keycloak-channel
     type: string

--- a/pipelines/test/aro/pipeline.yaml
+++ b/pipelines/test/aro/pipeline.yaml
@@ -30,7 +30,7 @@ spec:
       name: create-cmd-flags
       type: string
 # Kuadrant/RHCL installation related parameters
-    - default: quay.io/kuadrant/kuadrant-operator-catalog:v1.2.0
+    - default: quay.io/kuadrant/kuadrant-operator-catalog:v1.3.1
       description: Kuadrant/RHCL index image, leave empty to install current RHCL GA
       name: index-image
       type: string
@@ -42,12 +42,12 @@ spec:
       description: Operator name (kuadrant-operator, rhcl-operator)
       name: operator-name
       type: string
-    - default: ocp
-      description: Istio provider (ossm3, ocp), use ossm3 for OCP v4.18 and before
+    - default: ossm3
+      description: Istio provider (ossm3, ocp); 'ossm3' (recommended for all Openshift versions), 'ocp' for installing Istio managed by Gateway API on OCP v4.19+ (not recommended: mTLS is not supported).
       name: istio-provider
       type: string
     - default: ""
-      description: GatewayAPI CRD version. v1.0.0, v1.1.0, v1.2.1, v1.3.0 available; Leave empty if installing on OCP v4.19+
+      description: GatewayAPI CRD version. [v1.2.1, v1.3.0, v1.4.0] available; leave empty if installing on Openshift 4.19+.
       name: gateway-crd
       type: string
     - default: stable-v26

--- a/pipelines/test/osd-upgrade/pipeline.yaml
+++ b/pipelines/test/osd-upgrade/pipeline.yaml
@@ -54,12 +54,12 @@ spec:
       description: Operator name (kuadrant-operator, rhcl-operator)
       name: operator-name
       type: string
-    - default: ocp
-      description: Istio provider (ossm3, ocp), use ossm3 for OCP v4.18 and before
+    - default: ossm3
+      description: Istio provider (ossm3, ocp); 'ossm3' (recommended for all Openshift versions), 'ocp' for installing Istio managed by Gateway API on OCP v4.19+ (not recommended: mTLS is not supported).
       name: istio-provider
       type: string
     - default: ""
-      description: GatewayAPI CRD version. v1.0.0, v1.1.0, v1.2.1, v1.3.0 available; Leave empty if installing on OCP v4.19+
+      description: GatewayAPI CRD version. [v1.2.1, v1.3.0, v1.4.0] available; leave empty if installing on Openshift 4.19+.
       name: gateway-crd
       type: string
     - default: stable-v26

--- a/pipelines/test/osd/pipeline.yaml
+++ b/pipelines/test/osd/pipeline.yaml
@@ -42,7 +42,7 @@ spec:
       name: cluster-lifespan
       type: string
 # Kuadrant/RHCL installation related parameters
-    - default: quay.io/kuadrant/kuadrant-operator-catalog:v1.2.0
+    - default: quay.io/kuadrant/kuadrant-operator-catalog:v1.3.1
       description: Kuadrant/RHCL index image, leave empty to install current RHCL GA
       name: index-image
       type: string
@@ -54,12 +54,12 @@ spec:
       description: Operator name (kuadrant-operator, rhcl-operator)
       name: operator-name
       type: string
-    - default: ocp
-      description: Istio provider (ossm3, ocp), use ossm3 for OCP v4.18 and before
+    - default: ossm3
+      description: Istio provider (ossm3, ocp); 'ossm3' (recommended for all Openshift versions), 'ocp' for installing Istio managed by Gateway API on OCP v4.19+ (not recommended: mTLS is not supported).
       name: istio-provider
       type: string
     - default: ""
-      description: GatewayAPI CRD version. v1.0.0, v1.1.0, v1.2.1, v1.3.0 available; Leave empty if installing on OCP v4.19+
+      description: GatewayAPI CRD version. [v1.2.1, v1.3.0, v1.4.0] available; leave empty if installing on Openshift 4.19+.
       name: gateway-crd
       type: string
     - default: stable-v26

--- a/tasks/deploy/helm-deploy.yaml
+++ b/tasks/deploy/helm-deploy.yaml
@@ -10,10 +10,10 @@ spec:
     - description: Kuadrant image channel. Can be 'preview' for nightlies and 'stable' for releases
       name: channel
       type: string
-    - description: A 'ossm3' for Openshift Service mesh v3, 'ocp' for installing on Openshift 4.19+
+    - description: Istio provider (ossm3, ocp); 'ossm3' (recommended for all Openshift versions), 'ocp' for installing Istio managed by Gateway API on OCP v4.19+ (not recommended: mTLS is not supported).
       name: istio-provider
       type: string
-    - description: GatewayAPI CRD version. v1.0.0, v1.1.0, v1.2.1, v1.3.0 available; Leave empty if installing on ocp4.19+
+    - description: GatewayAPI CRD version. [v1.2.1, v1.3.0, v1.4.0] available; leave empty if installing on Openshift 4.19+.
       name: gateway-crd
       type: string
     - description: Keycloak subscription channel


### PR DESCRIPTION
 ## Summary
  Updates default parameter values and documentation for OCP 4.19+ compatibility based on mTLS deprecation concerns.

  On OpenShift 4.19+, while the `ocp` option is available (using Gateway API managed Istio), we now recommend using
  `ossm3` as the `istioProvider` due to mTLS deprecation concerns with the Gateway API approach.

  ## Changes
  - **`istio-provider`**: Default changed from `ocp` → `ossm3` (recommended for all OpenShift versions)
  - **`gateway-crd`**: Default changed from `v1.4.0` → `""` (leave empty for OCP 4.19+)
  - Updated parameter descriptions to clarify:
    - `ossm3` is recommended for all OpenShift versions (not just Service Mesh v3)
    - `ocp` option uses Gateway API managed Istio with deprecated mTLS support
    - `gateway-crd` should be left empty when installing on OpenShift 4.19+

  ## Files Updated
  - Deploy pipelines (kuadrant-testsuite, kuadrant-nightly-update)
  - Test pipelines (osd, aro, osd-upgrade)
  - Task definition (helm-deploy)

  ## Context
  Related to Kuadrant/kuadrant-operator#1701