### PR TITLE
fix: replace colon with dash in istio-provider description

### DIFF
--- a/pipelines/deploy/kuadrant-nightly-update/pipeline.yaml
+++ b/pipelines/deploy/kuadrant-nightly-update/pipeline.yaml
@@ -11,7 +11,7 @@ spec:
     name: cluster-credentials
     type: string
     default: openshift-pipelines-credentials
-  - description: Istio provider (ossm3, ocp); 'ossm3' (recommended for all Openshift versions), 'ocp' for installing Istio managed by Gateway API on OCP v4.19+ (not recommended: mTLS is not supported).
+  - description: Istio provider (ossm3, ocp); 'ossm3' (recommended for all Openshift versions), 'ocp' for installing Istio managed by Gateway API on OCP v4.19+ (not recommended - mTLS is not supported)
     name: istio-provider
     type: string
     default: ossm3

--- a/pipelines/deploy/kuadrant-testsuite/pipeline.yaml
+++ b/pipelines/deploy/kuadrant-testsuite/pipeline.yaml
@@ -23,7 +23,7 @@ spec:
     name: operator-name
     type: string
     default: kuadrant-operator
-  - description: Istio provider (ossm3, ocp); 'ossm3' (recommended for all Openshift versions), 'ocp' for installing Istio managed by Gateway API on OCP v4.19+ (not recommended: mTLS is not supported).
+  - description: Istio provider (ossm3, ocp); 'ossm3' (recommended for all Openshift versions), 'ocp' for installing Istio managed by Gateway API on OCP v4.19+ (not recommended - mTLS is not supported)
     name: istio-provider
     type: string
     default: ossm3

--- a/pipelines/test/aro/pipeline.yaml
+++ b/pipelines/test/aro/pipeline.yaml
@@ -43,7 +43,7 @@ spec:
       name: operator-name
       type: string
     - default: ossm3
-      description: Istio provider (ossm3, ocp); 'ossm3' (recommended for all Openshift versions), 'ocp' for installing Istio managed by Gateway API on OCP v4.19+ (not recommended: mTLS is not supported).
+      description: Istio provider (ossm3, ocp); 'ossm3' (recommended for all Openshift versions), 'ocp' for installing Istio managed by Gateway API on OCP v4.19+ (not recommended - mTLS is not supported)
       name: istio-provider
       type: string
     - default: ""

--- a/pipelines/test/osd-upgrade/pipeline.yaml
+++ b/pipelines/test/osd-upgrade/pipeline.yaml
@@ -55,7 +55,7 @@ spec:
       name: operator-name
       type: string
     - default: ossm3
-      description: Istio provider (ossm3, ocp); 'ossm3' (recommended for all Openshift versions), 'ocp' for installing Istio managed by Gateway API on OCP v4.19+ (not recommended: mTLS is not supported).
+      description: Istio provider (ossm3, ocp); 'ossm3' (recommended for all Openshift versions), 'ocp' for installing Istio managed by Gateway API on OCP v4.19+ (not recommended - mTLS is not supported)
       name: istio-provider
       type: string
     - default: ""

--- a/pipelines/test/osd/pipeline.yaml
+++ b/pipelines/test/osd/pipeline.yaml
@@ -55,7 +55,7 @@ spec:
       name: operator-name
       type: string
     - default: ossm3
-      description: Istio provider (ossm3, ocp); 'ossm3' (recommended for all Openshift versions), 'ocp' for installing Istio managed by Gateway API on OCP v4.19+ (not recommended: mTLS is not supported).
+      description: Istio provider (ossm3, ocp); 'ossm3' (recommended for all Openshift versions), 'ocp' for installing Istio managed by Gateway API on OCP v4.19+ (not recommended - mTLS is not supported)
       name: istio-provider
       type: string
     - default: ""

--- a/tasks/deploy/helm-deploy.yaml
+++ b/tasks/deploy/helm-deploy.yaml
@@ -10,7 +10,7 @@ spec:
     - description: Kuadrant image channel. Can be 'preview' for nightlies and 'stable' for releases
       name: channel
       type: string
-    - description: Istio provider (ossm3, ocp); 'ossm3' (recommended for all Openshift versions), 'ocp' for installing Istio managed by Gateway API on OCP v4.19+ (not recommended: mTLS is not supported).
+    - description: Istio provider (ossm3, ocp); 'ossm3' (recommended for all Openshift versions), 'ocp' for installing Istio managed by Gateway API on OCP v4.19+ (not recommended - mTLS is not supported)
       name: istio-provider
       type: string
     - description: GatewayAPI CRD version. [v1.2.1, v1.3.0, v1.4.0] available; leave empty if installing on Openshift 4.19+.


### PR DESCRIPTION
  ## Summary
  - Fix YAML syntax error in istio-provider parameter descriptions across all pipeline files

  ## Problem
  Pipeline files were failing to parse with error:
  `error: accumulating resources: accumulating resources from 'pipeline.yaml':
  MalformedYAMLError: yaml: line 58: mapping values are not allowed in this context`

  ## Solution
  Replaced unsupported `:` with `-` in parameter descriptions:
  - Changed `(not recommended: mTLS is not supported)`
  - To `(not recommended - mTLS is not supported)