### PR TITLE
Add separate Report Portal project for release pipelines

### DIFF
--- a/pipelines/test/aro/pipeline.yaml
+++ b/pipelines/test/aro/pipeline.yaml
@@ -97,7 +97,7 @@ spec:
       name: launch-description
       type: string
     - default: testsuite
-      description: Report Portal Project to store test results (testsuite or nightly-testsuite typically)
+      description: Report Portal Project to store test results (e.g. testsuite, nightly-testsuite, releases)
       name: rp-project
       type: string
     - default: true

--- a/pipelines/test/nightly/pipeline.yaml
+++ b/pipelines/test/nightly/pipeline.yaml
@@ -47,7 +47,7 @@ spec:
       name: launch-description
       type: string
     - default: nightly-testsuite
-      description: Report Portal Project to store test results (e.g. testsuite, nightly-testsuite)
+      description: Report Portal Project to store test results (e.g. testsuite, nightly-testsuite, releases)
       name: rp-project
       type: string
     - default: true

--- a/pipelines/test/osd-upgrade/pipeline.yaml
+++ b/pipelines/test/osd-upgrade/pipeline.yaml
@@ -113,7 +113,7 @@ spec:
       name: launch-description
       type: string
     - default: testsuite
-      description: Report Portal Project to store test results (testsuite or nightly-testsuite typically)
+      description: Report Portal Project to store test results (e.g. testsuite, nightly-testsuite, releases)
       name: rp-project
       type: string
     - default: true

--- a/pipelines/test/osd/pipeline.yaml
+++ b/pipelines/test/osd/pipeline.yaml
@@ -109,7 +109,7 @@ spec:
       name: launch-description
       type: string
     - default: testsuite
-      description: Report Portal Project to store test results (testsuite or nightly-testsuite typically)
+      description: Report Portal Project to store test results (e.g. testsuite, nightly-testsuite, releases)
       name: rp-project
       type: string
     - default: true

--- a/pipelines/test/release/pipeline.yaml
+++ b/pipelines/test/release/pipeline.yaml
@@ -46,8 +46,8 @@ spec:
       description: Optional launch description for Report Portal
       name: launch-description
       type: string
-    - default: testsuite
-      description: Report Portal Project to store test results (e.g. testsuite, nightly-testsuite)
+    - default: releases
+      description: Report Portal Project to store test results (e.g. testsuite, nightly-testsuite, releases)
       name: rp-project
       type: string
     - default: true

--- a/pipelines/test/testsuite/pipeline.yaml
+++ b/pipelines/test/testsuite/pipeline.yaml
@@ -44,7 +44,7 @@ spec:
       name: launch-description
       type: string
     - default: testsuite
-      description: Report Portal Project to store test results (e.g. testsuite, nightly-testsuite)
+      description: Report Portal Project to store test results (e.g. testsuite, nightly-testsuite, releases)
       name: rp-project
       type: string
     - default: true


### PR DESCRIPTION
I've copied the new Report Portal releases project permissions from the nightlies project