### PR TITLE
add UI testing support to pipelines

### DIFF
--- a/pipelines/test/nightly/pipeline.yaml
+++ b/pipelines/test/nightly/pipeline.yaml
@@ -8,6 +8,10 @@ spec:
       description: Testsuite image to run tests on
       name: testsuite-image
       type: string
+    - default: 'quay.io/kuadrant/testsuite-ui:unstable'
+      description: Testsuite UI image to run UI tests on
+      name: testsuite-ui-image
+      type: string
     - description: API URL of the Openshift cluster
       name: kube-api
       type: string
@@ -223,6 +227,32 @@ spec:
           value: $(params.additional-env)
         - name: kubeconfig-path
           value: $(tasks.kubectl-login.results.kubeconfig-path)
+        - name: cluster-credentials
+          value: $(params.cluster-credentials)
+      runAfter:
+        - run-tests-dnstls-gcp
+        - run-tests-dnstls-azure
+      taskRef:
+        kind: Task
+        name: run-tests
+      workspaces:
+        - name: shared-workspace
+    - name: run-tests-ui
+      params:
+        - name: testsuite-image
+          value: $(params.testsuite-ui-image)
+        - name: project
+          value: $(params.project)
+        - name: make-target
+          value: ui
+        - name: pytest-flags
+          value: $(params.pytest-flags)
+        - name: settings-cm
+          value: $(params.settings-cm)
+        - name: additional-env
+          value: $(params.additional-env)
+        - name: kubeconfig-path
+          value: $(tasks.kubectl-login-second-cluster.results.kubeconfig-path)
         - name: cluster-credentials
           value: $(params.cluster-credentials)
       runAfter:

--- a/pipelines/test/release/pipeline.yaml
+++ b/pipelines/test/release/pipeline.yaml
@@ -8,6 +8,10 @@ spec:
       description: Testsuite image to run tests on
       name: testsuite-image
       type: string
+    - default: 'quay.io/kuadrant/testsuite-ui:unstable'
+      description: Testsuite UI image to run UI tests on
+      name: testsuite-ui-image
+      type: string
     - description: API URL of the Openshift cluster
       name: kube-api
       type: string
@@ -345,6 +349,31 @@ spec:
       workspaces:
         - name: shared-workspace
 
+    - name: run-tests-ui
+      params:
+        - name: testsuite-image
+          value: $(params.testsuite-ui-image)
+        - name: project
+          value: $(params.project)
+        - name: make-target
+          value: ui
+        - name: pytest-flags
+          value: $(params.pytest-flags)
+        - name: settings-cm
+          value: $(params.settings-cm)
+        - name: additional-env
+          value: $(params.additional-env)
+        - name: kubeconfig-path
+          value: $(tasks.kubectl-login-second-cluster.results.kubeconfig-path)
+        - name: cluster-credentials
+          value: $(params.cluster-credentials)
+      runAfter:
+        - run-tests-multicluster-azure
+      taskRef:
+        kind: Task
+        name: run-tests
+      workspaces:
+        - name: shared-workspace
   finally:
     - name: upload-results
       when:

--- a/pipelines/test/testsuite/pipeline.yaml
+++ b/pipelines/test/testsuite/pipeline.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   params:
     - default: 'quay.io/kuadrant/testsuite:unstable'
-      description: Testsuite image to run tests on
+      description: Testsuite image to run tests on (use 'quay.io/kuadrant/testsuite-ui:unstable' for UI tests)
       name: testsuite-image
       type: string
     - description: API URL of the Openshift cluster


### PR DESCRIPTION
### Description

Add UI (Console Plugin) testing support to testsuite pipelines using the `testsuite-ui` image.
  
Closes #143 

 ### Changes

 - Integrated UI tests into `testsuite`, `nightly`, and `release` pipelines
 - UI tests run in parallel with disruptive tests on second cluster

 ### Verification

Applied task and pipelines to kua-hub cluster and verified `run-tests-ui` is integrated into pipeline executions.
