### PR TITLE
feat: Add wait for jobs flag for deploy

### DIFF
--- a/tasks/deploy/helm-deploy.yaml
+++ b/tasks/deploy/helm-deploy.yaml
@@ -130,7 +130,7 @@ spec:
       helm install -n=default
       --repo https://kuadrant.io/helm-charts-olm
       $(params.additional-helm-tools-flags)
-      --wait --debug
+      --wait --wait-for-jobs --debug
       tools-operators
       tools-operators
     env:
@@ -143,7 +143,7 @@ spec:
       helm install -n=default
       --repo https://kuadrant.io/helm-charts-olm
       $(params.additional-helm-tools-flags)
-      --wait --debug --timeout=10m0s
+      --wait --wait-for-jobs --debug --timeout=10m0s
       tools-instances
       tools-instances
     env:
@@ -163,7 +163,7 @@ spec:
       --set=gatewayAPI.version="$(params.gateway-crd)"
       --set=tools.enabled=true
       $(params.additional-helm-flags)
-      --wait --debug
+      --wait --wait-for-jobs --debug
       kuadrant-operators
       kuadrant-operators
     volumeMounts:
@@ -186,7 +186,7 @@ spec:
       --set=gatewayAPI.version="$(params.gateway-crd)"
       --set=tools.enabled=true
       $(params.additional-helm-flags)
-      --wait --debug
+      --wait --wait-for-jobs --debug
       kuadrant-instances
       kuadrant-instances
     volumeMounts:


### PR DESCRIPTION
In the helm chart there are wait jobs. It seems only `--wait` was enough for their function, but I recently found `--wait-for-jobs` flag, it should not hurt adding it.