### PR TITLE
refactor: increase run-tests task memory limits for UI tests

### DIFF
--- a/tasks/test/run-tests.yaml
+++ b/tasks/test/run-tests.yaml
@@ -40,10 +40,10 @@ spec:
       computeResources:
         limits:
           cpu: '2'
-          memory: 2000Mi
+          memory: 2500Mi
         requests:
           cpu: '1'
-          memory: 1000Mi
+          memory: 2000Mi
       env:
         - name: KUBECONFIG
           value: $(params.kubeconfig-path)


### PR DESCRIPTION
## Description         

Every couple of nightly runs UI tests are getting killed mid-execution with exit code 137 (Out of Memory) because 4 parallel Chromium browsers exceed the current 2GB memory limit.

## Changes

Updated `run-tests` task to cover spikes:
  - Memory limits: 2000Mi → 2500Mi 
  - Memory requests: 1000Mi → 2000Mi 

For regular tests this will be a slight over-allocation however the cluster has capacity for this increase. If any issues do occur we can separate into run-tests-ui task in future if needed.

## Analysis Results

I monitored 5 complete UI test runs:
  - Peak memory observed: 1924Mi, 1908Mi, 1891Mi, 1810Mi, 1750Mi
  - Consistent high usage across all runs
  - New 2500Mi limit provides ~30% buffer above peak memory observed

While monitoring didn't catch it exceeding 2000Mi, peaks came within 76Mi of the limit, with such a small gap to the limit it's no surprise OOM kills happen sometimes with the current memory allocation.