### PR TITLE
feat: replace upload-results with rptool and add collect-info task

### DIFF
--- a/pipelines/test/aro/pipeline.yaml
+++ b/pipelines/test/aro/pipeline.yaml
@@ -100,6 +100,10 @@ spec:
       description: If set to 'true' upload test results to Report Portal
       name: upload-results
       type: string
+    - default: 'quay.io/kuadrant/rptool:unstable'
+      description: rptool image for uploading results to Report Portal
+      name: rptool-image
+      type: string
 # Cleanup
     - default: false
       description: If set to 'true' cleanup will be done
@@ -238,6 +242,21 @@ spec:
       workspaces:
         - name: shared-workspace
           workspace: shared-workspace
+    - name: collect-info
+      params:
+        - name: testsuite-image
+          value: $(params.testsuite-image)
+        - name: settings-cm
+          value: $(params.settings-cm)
+        - name: kubeconfig-path
+          value: $(tasks.kubectl-login.results.kubeconfig-path)
+      runAfter:
+        - do-custom-updates
+      taskRef:
+        kind: Task
+        name: collect-info
+      workspaces:
+        - name: shared-workspace
     - name: run-tests
       params:
         - name: testsuite-image
@@ -257,13 +276,13 @@ spec:
         - name: cluster-credentials
           value: $(tasks.provision-aro.results.credentials-secret)
       runAfter:
-        - do-custom-updates
+        - collect-info
       taskRef:
         kind: Task
         name: run-tests
       workspaces:
         - name: shared-workspace
-    - name: upload-results
+    - name: rptool-upload
       when:
         - input: $(params.upload-results)
           operator: in
@@ -273,19 +292,17 @@ spec:
           value: $(params.launch-name)
         - name: launch-description
           value: $(params.launch-description)
-        - name: testsuite-image
-          value: $(params.testsuite-image)
+        - name: rptool-image
+          value: $(params.rptool-image)
         - name: make-target
           value: $(params.make-target)
         - name: rp-project
           value: $(params.rp-project)
-        - name: ocp-version
-          value: $(tasks.kubectl-login.results.ocp-version)
       runAfter:
         - run-tests
       taskRef:
         kind: Task
-        name: upload-results
+        name: rptool-upload
       workspaces:
         - name: shared-workspace
     - name: helm-uninstall-cleanup
@@ -297,7 +314,7 @@ spec:
         - name: kubeconfig-path
           value: $(tasks.kubectl-login.results.kubeconfig-path)
       runAfter:
-        - upload-results
+        - rptool-upload
         - run-tests
       taskRef:
         kind: Task

--- a/pipelines/test/nightly/pipeline.yaml
+++ b/pipelines/test/nightly/pipeline.yaml
@@ -58,6 +58,10 @@ spec:
       description: Upload test results to Report Portal
       name: upload-results
       type: string
+    - default: 'quay.io/kuadrant/rptool:unstable'
+      description: rptool image for uploading results to Report Portal
+      name: rptool-image
+      type: string
   tasks:
     - name: kubectl-login
       params:
@@ -70,6 +74,24 @@ spec:
       taskRef:
         kind: Task
         name: kubectl-login
+      workspaces:
+        - name: shared-workspace
+    - name: collect-info
+      params:
+        - name: testsuite-image
+          value: $(params.testsuite-image)
+        - name: settings-cm
+          value: $(params.settings-cm)
+        - name: kubeconfig-path
+          value: $(tasks.kubectl-login.results.kubeconfig-path)
+        - name: additional-env
+          value: 'KUADRANT_CONTROL_PLANE__cluster2__kubeconfig_path=$(tasks.kubectl-login-second-cluster.results.kubeconfig-path)'
+      runAfter:
+        - kubectl-login
+        - kubectl-login-second-cluster
+      taskRef:
+        kind: Task
+        name: collect-info
       workspaces:
         - name: shared-workspace
     - name: run-tests-kuadrant
@@ -91,7 +113,7 @@ spec:
         - name: cluster-credentials
           value: $(params.cluster-credentials)
       runAfter:
-        - kubectl-login
+        - collect-info
       taskRef:
         kind: Task
         name: run-tests
@@ -129,7 +151,7 @@ spec:
         - name: cluster-credentials
           value: $(params.cluster-credentials)
       runAfter:
-        - kubectl-login-second-cluster
+        - collect-info
       taskRef:
         kind: Task
         name: run-tests
@@ -264,7 +286,7 @@ spec:
       workspaces:
         - name: shared-workspace
   finally:
-    - name: upload-results
+    - name: rptool-upload
       when:
         - input: $(params.upload-results)
           operator: in
@@ -274,17 +296,15 @@ spec:
           value: $(params.launch-name)
         - name: launch-description
           value: $(params.launch-description)
-        - name: testsuite-image
-          value: $(params.testsuite-image)
+        - name: rptool-image
+          value: $(params.rptool-image)
         - name: make-target
           value: all
         - name: rp-project
           value: $(params.rp-project)
-        - name: ocp-version
-          value: $(tasks.kubectl-login.results.ocp-version)
       taskRef:
         kind: Task
-        name: upload-results
+        name: rptool-upload
       workspaces:
         - name: shared-workspace
   workspaces:

--- a/pipelines/test/ocp-aws/pipeline.yaml
+++ b/pipelines/test/ocp-aws/pipeline.yaml
@@ -93,6 +93,10 @@ spec:
       description: If set to 'true' upload test results to Report Portal
       name: upload-results
       type: string
+    - default: 'quay.io/kuadrant/rptool:unstable'
+      description: rptool image for uploading results to Report Portal
+      name: rptool-image
+      type: string
     # Cleanup
     - default: false
       description: If set to 'true' cleanup will be done
@@ -161,6 +165,22 @@ spec:
       workspaces:
         - name: shared-workspace
           workspace: shared-workspace
+    - name: collect-info
+      params:
+        - name: testsuite-image
+          value: $(params.testsuite-image)
+        - name: settings-cm
+          value: $(params.settings-cm)
+        - name: kubeconfig-path
+          value: $(tasks.provision-ocp-aws.results.kubeconfig-path)
+      runAfter:
+        - do-custom-updates
+      taskRef:
+        kind: Task
+        name: collect-info
+      workspaces:
+        - name: shared-workspace
+          workspace: shared-workspace
     - name: run-tests
       timeout: "2h"
       params:
@@ -181,14 +201,14 @@ spec:
         - name: cluster-credentials
           value: $(tasks.provision-ocp-aws.results.credentials-secret)
       runAfter:
-        - do-custom-updates
+        - collect-info
       taskRef:
         kind: Task
         name: run-tests
       workspaces:
         - name: shared-workspace
           workspace: shared-workspace
-    - name: upload-results
+    - name: rptool-upload
       when:
         - input: $(params.upload-results)
           operator: in
@@ -198,19 +218,17 @@ spec:
           value: $(params.launch-name)
         - name: launch-description
           value: $(params.launch-description)
-        - name: testsuite-image
-          value: $(params.testsuite-image)
+        - name: rptool-image
+          value: $(params.rptool-image)
         - name: make-target
           value: $(params.make-target)
         - name: rp-project
           value: $(params.rp-project)
-        - name: ocp-version
-          value: $(tasks.provision-ocp-aws.results.ocp-version)
       runAfter:
         - run-tests
       taskRef:
         kind: Task
-        name: upload-results
+        name: rptool-upload
       workspaces:
         - name: shared-workspace
           workspace: shared-workspace
@@ -220,7 +238,7 @@ spec:
           operator: in
           values: ["true"]
       runAfter:
-        - upload-results
+        - rptool-upload
       params:
         - name: cluster-name
           value: $(params.cluster-name)

--- a/pipelines/test/osd-upgrade/pipeline.yaml
+++ b/pipelines/test/osd-upgrade/pipeline.yaml
@@ -116,6 +116,10 @@ spec:
       description: If set to 'true' upload test results to Report Portal
       name: upload-results
       type: string
+    - default: 'quay.io/kuadrant/rptool:unstable'
+      description: rptool image for uploading results to Report Portal
+      name: rptool-image
+      type: string
 # Cleanup
     - default: false
       description: If set to 'true' cleanup will be done
@@ -450,6 +454,21 @@ spec:
       taskRef:
         kind: Task
         name: pause-pipeline
+    - name: collect-info
+      params:
+        - name: testsuite-image
+          value: $(params.testsuite-image)
+        - name: settings-cm
+          value: $(params.settings-cm)
+        - name: kubeconfig-path
+          value: $(tasks.kubectl-login.results.kubeconfig-path)
+      runAfter:
+        - pause-pipeline-post-upgrade
+      taskRef:
+        kind: Task
+        name: collect-info
+      workspaces:
+        - name: shared-workspace
     - name: run-tests-post-upgrade
       params:
         - name: testsuite-image
@@ -469,13 +488,13 @@ spec:
         - name: cluster-credentials
           value: $(tasks.get-osd-credentials.results.credentials-secret)
       runAfter:
-        - pause-pipeline-post-upgrade
+        - collect-info
       taskRef:
         kind: Task
         name: run-tests
       workspaces:
         - name: shared-workspace
-    - name: upload-results
+    - name: rptool-upload
       when:
         - input: $(params.upload-results)
           operator: in
@@ -485,19 +504,17 @@ spec:
           value: $(params.launch-name)
         - name: launch-description
           value: $(params.launch-description)
-        - name: testsuite-image
-          value: $(params.testsuite-image)
+        - name: rptool-image
+          value: $(params.rptool-image)
         - name: make-target
           value: $(params.post-upgrade-make-target)
         - name: rp-project
           value: $(params.rp-project)
-        - name: ocp-version
-          value: $(tasks.kubectl-login.results.ocp-version)
       runAfter:
         - run-tests-post-upgrade
       taskRef:
         kind: Task
-        name: upload-results
+        name: rptool-upload
       workspaces:
         - name: shared-workspace
     - name: helm-uninstall-cleanup
@@ -509,7 +526,7 @@ spec:
         - name: kubeconfig-path
           value: $(tasks.kubectl-login.results.kubeconfig-path)
       runAfter:
-        - upload-results
+        - rptool-upload
         - run-tests-post-upgrade
       taskRef:
         kind: Task

--- a/pipelines/test/osd/pipeline.yaml
+++ b/pipelines/test/osd/pipeline.yaml
@@ -112,6 +112,10 @@ spec:
       description: If set to 'true' upload test results to Report Portal
       name: upload-results
       type: string
+    - default: 'quay.io/kuadrant/rptool:unstable'
+      description: rptool image for uploading results to Report Portal
+      name: rptool-image
+      type: string
 # Cleanup
     - default: false
       description: If set to 'true' cleanup will be done
@@ -398,6 +402,21 @@ spec:
       workspaces:
         - name: shared-workspace
           workspace: shared-workspace
+    - name: collect-info
+      params:
+        - name: testsuite-image
+          value: $(params.testsuite-image)
+        - name: settings-cm
+          value: $(params.settings-cm)
+        - name: kubeconfig-path
+          value: $(tasks.kubectl-login.results.kubeconfig-path)
+      runAfter:
+        - do-custom-updates
+      taskRef:
+        kind: Task
+        name: collect-info
+      workspaces:
+        - name: shared-workspace
     - name: run-tests
       params:
         - name: testsuite-image
@@ -417,13 +436,13 @@ spec:
         - name: cluster-credentials
           value: $(tasks.get-osd-credentials.results.credentials-secret)
       runAfter:
-        - do-custom-updates
+        - collect-info
       taskRef:
         kind: Task
         name: run-tests
       workspaces:
         - name: shared-workspace
-    - name: upload-results
+    - name: rptool-upload
       when:
         - input: $(params.upload-results)
           operator: in
@@ -433,19 +452,17 @@ spec:
           value: $(params.launch-name)
         - name: launch-description
           value: $(params.launch-description)
-        - name: testsuite-image
-          value: $(params.testsuite-image)
+        - name: rptool-image
+          value: $(params.rptool-image)
         - name: make-target
           value: $(params.make-target)
         - name: rp-project
           value: $(params.rp-project)
-        - name: ocp-version
-          value: $(tasks.kubectl-login.results.ocp-version)
       runAfter:
         - run-tests
       taskRef:
         kind: Task
-        name: upload-results
+        name: rptool-upload
       workspaces:
         - name: shared-workspace
     - name: helm-uninstall-cleanup
@@ -457,7 +474,7 @@ spec:
         - name: kubeconfig-path
           value: $(tasks.kubectl-login.results.kubeconfig-path)
       runAfter:
-        - upload-results
+        - rptool-upload
         - run-tests
       taskRef:
         kind: Task

--- a/pipelines/test/release/pipeline.yaml
+++ b/pipelines/test/release/pipeline.yaml
@@ -58,6 +58,10 @@ spec:
       description: Upload test results to Report Portal
       name: upload-results
       type: string
+    - default: 'quay.io/kuadrant/rptool:unstable'
+      description: rptool image for uploading results to Report Portal
+      name: rptool-image
+      type: string
   tasks:
     - name: kubectl-login
       params:
@@ -70,6 +74,25 @@ spec:
       taskRef:
         kind: Task
         name: kubectl-login
+      workspaces:
+        - name: shared-workspace
+
+    - name: collect-info
+      params:
+        - name: testsuite-image
+          value: $(params.testsuite-image)
+        - name: settings-cm
+          value: $(params.settings-cm)
+        - name: kubeconfig-path
+          value: $(tasks.kubectl-login.results.kubeconfig-path)
+        - name: additional-env
+          value: 'KUADRANT_CONTROL_PLANE__cluster2__kubeconfig_path=$(tasks.kubectl-login-second-cluster.results.kubeconfig-path)'
+      runAfter:
+        - kubectl-login
+        - kubectl-login-second-cluster
+      taskRef:
+        kind: Task
+        name: collect-info
       workspaces:
         - name: shared-workspace
 
@@ -92,7 +115,7 @@ spec:
         - name: cluster-credentials
           value: $(params.cluster-credentials)
       runAfter:
-        - kubectl-login
+        - collect-info
       taskRef:
         kind: Task
         name: run-tests
@@ -158,7 +181,7 @@ spec:
         - name: cluster-credentials
           value: $(params.cluster-credentials)
       runAfter:
-        - kubectl-login-second-cluster
+        - collect-info
       taskRef:
         kind: Task
         name: run-tests
@@ -375,7 +398,7 @@ spec:
       workspaces:
         - name: shared-workspace
   finally:
-    - name: upload-results
+    - name: rptool-upload
       when:
         - input: $(params.upload-results)
           operator: in
@@ -385,17 +408,15 @@ spec:
           value: $(params.launch-name)
         - name: launch-description
           value: $(params.launch-description)
-        - name: testsuite-image
-          value: $(params.testsuite-image)
+        - name: rptool-image
+          value: $(params.rptool-image)
         - name: make-target
           value: all
         - name: rp-project
           value: $(params.rp-project)
-        - name: ocp-version
-          value: $(tasks.kubectl-login.results.ocp-version)
       taskRef:
         kind: Task
-        name: upload-results
+        name: rptool-upload
       workspaces:
         - name: shared-workspace
   workspaces:

--- a/pipelines/test/testsuite/pipeline.yaml
+++ b/pipelines/test/testsuite/pipeline.yaml
@@ -51,6 +51,10 @@ spec:
       description: Upload test results to Report Portal
       name: upload-results
       type: string
+    - default: 'quay.io/kuadrant/rptool:unstable'
+      description: rptool image for uploading results to Report Portal
+      name: rptool-image
+      type: string
   tasks:
     - name: kubectl-login
       params:
@@ -63,6 +67,21 @@ spec:
       taskRef:
         kind: Task
         name: kubectl-login
+      workspaces:
+        - name: shared-workspace
+    - name: collect-info
+      params:
+        - name: testsuite-image
+          value: $(params.testsuite-image)
+        - name: settings-cm
+          value: $(params.settings-cm)
+        - name: kubeconfig-path
+          value: $(tasks.kubectl-login.results.kubeconfig-path)
+      runAfter:
+        - kubectl-login
+      taskRef:
+        kind: Task
+        name: collect-info
       workspaces:
         - name: shared-workspace
     - name: run-tests
@@ -84,14 +103,14 @@ spec:
         - name: cluster-credentials
           value: $(params.cluster-credentials)
       runAfter:
-        - kubectl-login
+        - collect-info
       taskRef:
         kind: Task
         name: run-tests
       workspaces:
         - name: shared-workspace
   finally:
-    - name: upload-results
+    - name: rptool-upload
       when:
         - input: $(params.upload-results)
           operator: in
@@ -101,17 +120,15 @@ spec:
           value: $(params.launch-name)
         - name: launch-description
           value: $(params.launch-description)
-        - name: testsuite-image
-          value: $(params.testsuite-image)
+        - name: rptool-image
+          value: $(params.rptool-image)
         - name: make-target
           value: $(params.make-target)
         - name: rp-project
           value: $(params.rp-project)
-        - name: ocp-version
-          value: $(tasks.kubectl-login.results.ocp-version)
       taskRef:
         kind: Task
-        name: upload-results
+        name: rptool-upload
       workspaces:
         - name: shared-workspace
   workspaces:

--- a/pipelines/test/upgrade/pipeline.yaml
+++ b/pipelines/test/upgrade/pipeline.yaml
@@ -87,6 +87,10 @@ spec:
       description: If set to 'true' upload test results to Report Portal
       name: upload-results
       type: string
+    - default: 'quay.io/kuadrant/rptool:unstable'
+      description: rptool image for uploading results to Report Portal
+      name: rptool-image
+      type: string
   workspaces:
     - name: shared-workspace
   tasks:
@@ -205,6 +209,22 @@ spec:
       taskRef:
         kind: Task
         name: pause-pipeline
+    - name: collect-info
+      params:
+        - name: testsuite-image
+          value: $(params.testsuite-image)
+        - name: settings-cm
+          value: $(params.settings-cm)
+        - name: kubeconfig-path
+          value: $(tasks.kubectl-login.results.kubeconfig-path)
+      runAfter:
+        - pause-pipeline-post-upgrade
+      taskRef:
+        kind: Task
+        name: collect-info
+      workspaces:
+        - name: shared-workspace
+          workspace: shared-workspace
     - name: run-tests-post-upgrade
       params:
         - name: testsuite-image
@@ -224,14 +244,14 @@ spec:
         - name: cluster-credentials
           value: $(params.cluster-credentials)
       runAfter:
-        - pause-pipeline-post-upgrade
+        - collect-info
       taskRef:
         kind: Task
         name: run-tests
       workspaces:
         - name: shared-workspace
           workspace: shared-workspace
-    - name: upload-results
+    - name: rptool-upload
       when:
         - input: $(params.upload-results)
           operator: in
@@ -241,19 +261,17 @@ spec:
           value: $(params.launch-name)
         - name: launch-description
           value: $(params.launch-description)
-        - name: testsuite-image
-          value: $(params.testsuite-image)
+        - name: rptool-image
+          value: $(params.rptool-image)
         - name: make-target
           value: $(params.post-upgrade-make-target)
         - name: rp-project
           value: $(params.rp-project)
-        - name: ocp-version
-          value: $(tasks.kubectl-login.results.ocp-version)
       runAfter:
         - run-tests-post-upgrade
       taskRef:
         kind: Task
-        name: upload-results
+        name: rptool-upload
       workspaces:
         - name: shared-workspace
           workspace: shared-workspace

--- a/tasks/test/collect-info.yaml
+++ b/tasks/test/collect-info.yaml
@@ -1,0 +1,52 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: collect-info
+spec:
+  params:
+    - description: Testsuite image to run info collection on
+      name: testsuite-image
+      type: string
+    - description: Config Map with settings for the testsuite
+      name: settings-cm
+      type: string
+    - description: Path to workspace kubeconfig
+      name: kubeconfig-path
+      type: string
+    - description: Additional env for testsuite container separated with spaces (e.g. KUADRANT_CONTROL_PLANE__cluster2__kubeconfig_path=/workspace/cluster2)
+      name: additional-env
+      type: string
+      default: ""
+  steps:
+    - args:
+        - >-
+          cp /var/kuadrant-settings/settings.local.yaml /opt/workdir/kuadrant-testsuite/config &&
+          export $(params.additional-env) &> /dev/null &&
+          (make collect || true)
+      command:
+        - /bin/bash
+        - -cveo
+        - pipefail
+      computeResources:
+        limits:
+          cpu: '250m'
+          memory: 256Mi
+      env:
+        - name: KUBECONFIG
+          value: $(params.kubeconfig-path)
+        - name: WORKSPACE
+          value: $(workspaces.shared-workspace.path)
+        - name: COLLECTOR_ENABLE
+          value: "true"
+      image: $(params.testsuite-image)
+      imagePullPolicy: Always
+      name: collect-info
+      volumeMounts:
+        - mountPath: /var/kuadrant-settings
+          name: $(params.settings-cm)
+  volumes:
+    - configMap:
+        name: $(params.settings-cm)
+      name: $(params.settings-cm)
+  workspaces:
+    - name: shared-workspace

--- a/tasks/test/kustomization.yaml
+++ b/tasks/test/kustomization.yaml
@@ -3,4 +3,5 @@ kind: Component
 
 resources:
   - run-tests.yaml
-  - upload-results.yaml
+  - collect-info.yaml
+  - rptool-upload.yaml

--- a/tasks/test/rptool-upload.yaml
+++ b/tasks/test/rptool-upload.yaml
@@ -1,7 +1,7 @@
 apiVersion: tekton.dev/v1
 kind: Task
 metadata:
-  name: upload-results
+  name: rptool-upload
 spec:
   params:
     - description: Prefix of the launch name saved in report portal (nightly, username, manual, etc.)
@@ -10,8 +10,8 @@ spec:
     - description: Launch description for Report Portal
       name: launch-description
       type: string
-    - description: Testsuite image to run tests on
-      name: testsuite-image
+    - description: rptool image to use for uploading results
+      name: rptool-image
       type: string
     - description: Makefile target for tests
       name: make-target
@@ -19,12 +19,10 @@ spec:
     - description: Report Portal Project to store test results
       name: rp-project
       type: string
-    - description: OCP cluster version
-      name: ocp-version
-      type: string
   steps:
     - args:
-        - make reportportal
+        - >-
+          rptool write --launch-name "${RP_LAUNCH_NAME}" --launch-description "${RP_LAUNCH_DESC}" ${WORKSPACE}/junit-*.xml
       command:
         - /bin/bash
         - -cveo
@@ -32,15 +30,17 @@ spec:
       computeResources:
         limits:
           cpu: '250m'
-          memory: 128Mi
+          memory: 256Mi
       env:
         - name: WORKSPACE
           value: $(workspaces.shared-workspace.path)
         - name: RP_LAUNCH_NAME
           value: $(params.launch-name)-$(params.make-target)
+        - name: RP_LAUNCH_DESC
+          value: $(params.launch-description)
         - name: RP_PROJECT
           value: $(params.rp-project)
-        - name: REPORTPORTAL
+        - name: RP_URL
           valueFrom:
             secretKeyRef:
               key: RP_URL
@@ -52,13 +52,9 @@ spec:
               name: rp-credentials
         - name: REQUESTS_CA_BUNDLE
           value: /var/ca-bundle/tls-ca-bundle.pem
-        - name: RP_LAUNCH_DESC
-          value: $(params.launch-description)
-        - name: OCP_VERSION
-          value: $(params.ocp-version)
-      image: $(params.testsuite-image)
+      image: $(params.rptool-image)
       imagePullPolicy: Always
-      name: upload-results
+      name: rptool-upload
       volumeMounts:
         - mountPath: /var/ca-bundle
           name: rp-ca-bundle


### PR DESCRIPTION
## Summary

  - Replace `upload-results` task (`make reportportal` in testsuite image) with standalone `rptool` CLI for importing JUnit results into ReportPortal
  - Add `collect-info` task that runs `make collect` to gather cluster metadata (Kubernetes version, Kuadrant component images, Istio version) into `junit-00-collect.xml`
  - Update all 8 test pipelines to use the new tasks
  - OCP version and launch description are now derived from collected cluster metadata instead of being passed manually

## Changes

  ### New tasks
  - **`collect-info`** — runs `make collect` in the testsuite image after cluster login, produces `junit-00-collect.xml` with cluster metadata. Supports multi-cluster collection via `additional-env` parameter.
  - **`rptool-upload`** — uses `quay.io/kuadrant/rptool:unstable` image to run `rptool write` and import all JUnit XMLs (including collected metadata) into ReportPortal.

## Dependencies
  - Kuadrant/testsuite#911 
  - (for testing you can use this testsuite image `quay.io/rh-ee-starabov/testsuite:report-portal`)

**Note**                                                                                                                                                                            
  Pipelines from this branch are deployed on the `hub-419` cluster and available for testing

  Closes #161 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Refactored test pipeline infrastructure to use a dedicated Report Portal upload tool, separate from the test suite container image
  * Introduced a new information collection step in test pipelines to prepare test environment configuration
  * Updated pipeline parameters to support separate configuration of the Report Portal upload component across all test pipeline variants (ARO, OCP-AWS, OSD, OSD-Upgrade, Release, Nightly, TestSuite and Upgrade pipelines)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->