### PR TITLE
fix: reorder release pipeline

### DIFF
--- a/pipelines/test/release/pipeline.yaml
+++ b/pipelines/test/release/pipeline.yaml
@@ -234,7 +234,7 @@ spec:
           value: $(params.cluster-credentials)
       runAfter:
         - run-tests-kuadrant
-        - run-tests-authorino-standalone
+        - run-tests-ui
       taskRef:
         kind: Task
         name: run-tests
@@ -391,7 +391,7 @@ spec:
         - name: cluster-credentials
           value: $(params.cluster-credentials)
       runAfter:
-        - run-tests-multicluster-azure
+        - run-tests-authorino-standalone
       taskRef:
         kind: Task
         name: run-tests


### PR DESCRIPTION
## Summary
  - Fix cluster conflict in the release pipeline where `disruptive` and `ui` tasks both ran on the second cluster in parallel
  - Move `ui` tests to run after `authorino-standalone` (in parallel with `kuadrant`), saving pipeline time by utilizing idle cluster 2
  - Pipeline is deployed on hub-419 cluster for testing