### PR TITLE
add oc CLI and Node.js to pipeline tools image

### DIFF
--- a/init-container.sh
+++ b/init-container.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
-set -o pipefail
+set -euo pipefail
 
 case "${TARGETPLATFORM}" in
-    "linux/amd64") ARCH=amd64 && ROSA_ARCH=x86_64 && AWS_ARCH=x86_64 ;;
-    "linux/arm64") ARCH=arm64 && ROSA_ARCH=arm64 && AWS_ARCH=aarch64 ;;
+    "linux/amd64") ARCH=amd64 && ROSA_ARCH=x86_64 && AWS_ARCH=x86_64 && NODE_ARCH=x64 ;;
+    "linux/arm64") ARCH=arm64 && ROSA_ARCH=arm64 && AWS_ARCH=aarch64 && NODE_ARCH=arm64 ;;
     *) exit 1 ;;
 esac
 
-microdnf -y install jq tar git buildah findutils unzip python3.11 python3.11-pip
+microdnf -y install jq tar xz git buildah findutils unzip python3.11 python3.11-pip make gettext
 
 curl -LSs -o /usr/local/bin/ocm "https://github.com/openshift-online/ocm-cli/releases/download/$(curl -Lfs https://api.github.com/repos/openshift-online/ocm-cli/releases/latest \
     | jq -r .tag_name)/ocm-linux-${ARCH}" \
@@ -16,6 +16,10 @@ curl -Lfs "https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3" 
 
 curl -LSs -o /usr/local/bin/kubectl "https://dl.k8s.io/release/$(curl -Lfs https://dl.k8s.io/release/stable.txt)/bin/linux/${ARCH}/kubectl" \
     && chmod 0755 /usr/local/bin/kubectl
+
+curl -Lfs "https://mirror.openshift.com/pub/openshift-v4/${AWS_ARCH}/clients/ocp/stable/openshift-client-linux-${ARCH}-rhel9.tar.gz" | \
+    tar -xz -f - -C /usr/local/bin 'oc' \
+    && chmod 0755 /usr/local/bin/oc
 
 curl -Lfs "https://github.com/openshift/rosa/releases/download/$(curl -Lfs https://api.github.com/repos/openshift/rosa/releases/latest \
     | jq -r .tag_name)/rosa_Linux_${ROSA_ARCH}.tar.gz" | \
@@ -29,6 +33,10 @@ curl -LSs -o /usr/local/bin/opm "https://github.com/operator-framework/operator-
 curl -LSs -o /usr/local/bin/cli53 "https://github.com/barnybug/cli53/releases/download/$(curl -Lfs https://api.github.com/repos/barnybug/cli53/releases/latest \
     | jq -r .tag_name)/cli53-linux-${ARCH}" \
     && chmod 0755 /usr/local/bin/cli53
+
+NODE_VERSION=$(curl -Lfs https://nodejs.org/dist/index.json | jq -r '[.[] | select(.lts != false)][0].version') \
+    && curl -Lfs "https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" | \
+    tar -xJ -f - --strip-components=1 -C /usr/local
 
 curl -LSs -o awscli.zip "https://awscli.amazonaws.com/awscli-exe-linux-${AWS_ARCH}.zip" \
     && unzip awscli.zip \


### PR DESCRIPTION
### Summary
Install OpenShift CLI (oc) and latest LTS Node.js in the pipeline tools image. Also improve error handling with stricter bash options.

These changes are required for MCP Gateway pipeline (draft state atm):
https://github.com/Kuadrant/testsuite-pipelines/pull/158

### Changes
  - Add oc client installation from OpenShift mirror
  - Add Node.js LTS installation with architecture support
  - Install additional dependencies: xz (for Node.js), make
  - Strengthen bash error handling: set -euo pipefail
  - Add NODE_ARCH variable for x64/arm64 Node.js binaries
  
### Verification
Build the container image locally. You can follow readme for that:
https://github.com/Kuadrant/testsuite-pipelines#docker

Run the container and verify tools are installed:
```bash
     docker run <image> oc version --client
     docker run <image> node --version
     docker run <image> npm --version
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Stricter container initialisation error handling and expanded multi-architecture detection.
  * Automated installation of the OpenShift cli and the latest Node.js LTS during container setup, plus additional runtime tools to ensure consistent environments across deployments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/testsuite-pipelines/pull/167)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->