### PR TITLE
feat: added extensions image parameter

### DIFF
--- a/pipelines/deploy/kuadrant-nightly-update/pipeline.yaml
+++ b/pipelines/deploy/kuadrant-nightly-update/pipeline.yaml
@@ -26,7 +26,7 @@ spec:
   - description: Extensions image to overwrite default one.
     name: extensions-image
     type: string
-    default: ""
+    default: "quay.io/kuadrant/internal-extensions:latest"
   - description: Additional flags for helm install command, example '--set=kuadrant.installPlanApproval=Manual --set=kuadrant.startingCSV=kuadrant-operator.v1.2.0'
     name: additional-helm-flags
     type: string

--- a/pipelines/deploy/kuadrant-nightly-update/pipeline.yaml
+++ b/pipelines/deploy/kuadrant-nightly-update/pipeline.yaml
@@ -78,6 +78,8 @@ spec:
         value: $(params.operator-name)
       - name: kubeconfig-path
         value: $(tasks.kubectl-login.results.kubeconfig-path)
+      - name: extensions-image
+        value: $(params.extensions-image)
       - name: additional-helm-flags
         value: $(params.additional-helm-flags)
       - name: additional-helm-tools-flags

--- a/pipelines/deploy/kuadrant-nightly-update/pipeline.yaml
+++ b/pipelines/deploy/kuadrant-nightly-update/pipeline.yaml
@@ -23,6 +23,10 @@ spec:
     name: gateway-crd
     type: string
     default: ""
+  - description: Extensions image to overwrite default one.
+    name: extensions-image
+    type: string
+    default: ""
   - description: Additional flags for helm install command, example '--set=kuadrant.installPlanApproval=Manual --set=kuadrant.startingCSV=kuadrant-operator.v1.2.0'
     name: additional-helm-flags
     type: string

--- a/pipelines/deploy/kuadrant-testsuite/pipeline.yaml
+++ b/pipelines/deploy/kuadrant-testsuite/pipeline.yaml
@@ -31,6 +31,10 @@ spec:
     name: gateway-crd
     type: string
     default: ""
+  - description: Extensions image to overwrite default one.
+    name: extensions-image
+    type: string
+    default: ""
   - description: Additional flags for helm install command, example '--set=kuadrant.installPlanApproval=Manual --set=kuadrant.startingCSV=kuadrant-operator.v1.2.0'
     name: additional-helm-flags
     type: string

--- a/pipelines/deploy/kuadrant-testsuite/pipeline.yaml
+++ b/pipelines/deploy/kuadrant-testsuite/pipeline.yaml
@@ -34,7 +34,7 @@ spec:
   - description: Extensions image to overwrite default one.
     name: extensions-image
     type: string
-    default: ""
+    default: "quay.io/kuadrant/internal-extensions:latest"
   - description: Additional flags for helm install command, example '--set=kuadrant.installPlanApproval=Manual --set=kuadrant.startingCSV=kuadrant-operator.v1.2.0'
     name: additional-helm-flags
     type: string

--- a/pipelines/deploy/kuadrant-testsuite/pipeline.yaml
+++ b/pipelines/deploy/kuadrant-testsuite/pipeline.yaml
@@ -86,6 +86,8 @@ spec:
         value: $(params.operator-name)
       - name: kubeconfig-path
         value: $(tasks.kubectl-login.results.kubeconfig-path)
+      - name: extensions-image
+        value: $(params.extensions-image)
       - name: additional-helm-flags
         value: $(params.additional-helm-flags)
       - name: additional-helm-tools-flags

--- a/pipelines/test/aro/pipeline.yaml
+++ b/pipelines/test/aro/pipeline.yaml
@@ -51,6 +51,10 @@ spec:
       name: gateway-crd
       type: string
     - default: ""
+      description: Extensions image to overwrite default one.
+      name: extensions-image
+      type: string
+    - default: ""
       description: Additional flags for helm install command, example '--set=kuadrant.installPlanApproval=Manual --set=kuadrant.startingCSV=kuadrant-operator.v1.2.0'
       name: additional-helm-flags
       type: string
@@ -204,6 +208,8 @@ spec:
           value: $(tasks.kubectl-login.results.kubeconfig-path)
         - name: gateway-crd
           value: $(params.gateway-crd)
+        - name: extensions-image
+          value: $(params.extensions-image)
         - name: additional-helm-flags
           value: $(params.additional-helm-flags)
         - name: additional-helm-tools-flags

--- a/pipelines/test/aro/pipeline.yaml
+++ b/pipelines/test/aro/pipeline.yaml
@@ -50,7 +50,7 @@ spec:
       description: GatewayAPI CRD version. [v1.2.1, v1.3.0, v1.4.0] available; leave empty if installing on Openshift 4.19+.
       name: gateway-crd
       type: string
-    - default: ""
+    - default: "quay.io/kuadrant/internal-extensions:latest"
       description: Extensions image to overwrite default one.
       name: extensions-image
       type: string

--- a/pipelines/test/ocp-aws/pipeline.yaml
+++ b/pipelines/test/ocp-aws/pipeline.yaml
@@ -44,6 +44,10 @@ spec:
       name: gateway-crd
       type: string
     - default: ""
+      description: Extensions image to overwrite default one.
+      name: extensions-image
+      type: string
+    - default: ""
       description: Additional flags for helm install command, example '--set=kuadrant.installPlanApproval=Manual --set=kuadrant.startingCSV=kuadrant-operator.v1.2.0'
       name: additional-helm-flags
       type: string
@@ -141,6 +145,8 @@ spec:
           value: $(tasks.provision-ocp-aws.results.kubeconfig-path)
         - name: gateway-crd
           value: $(params.gateway-crd)
+        - name: extensions-image
+          value: $(params.extensions-image)
         - name: additional-helm-flags
           value: $(params.additional-helm-flags)
         - name: additional-helm-tools-flags

--- a/pipelines/test/ocp-aws/pipeline.yaml
+++ b/pipelines/test/ocp-aws/pipeline.yaml
@@ -43,11 +43,11 @@ spec:
       description: GatewayAPI CRD version. [v1.2.1, v1.3.0, v1.4.0] available; leave empty if installing on Openshift 4.19+.
       name: gateway-crd
       type: string
-    - default: ""
+    - default: "quay.io/kuadrant/internal-extensions:latest"
       description: Extensions image to overwrite default one.
       name: extensions-image
       type: string
-    - default: "quay.io/kuadrant/internal-extensions:latest"
+    - default: ""
       description: Additional flags for helm install command, example '--set=kuadrant.installPlanApproval=Manual --set=kuadrant.startingCSV=kuadrant-operator.v1.2.0'
       name: additional-helm-flags
       type: string

--- a/pipelines/test/ocp-aws/pipeline.yaml
+++ b/pipelines/test/ocp-aws/pipeline.yaml
@@ -47,7 +47,7 @@ spec:
       description: Extensions image to overwrite default one.
       name: extensions-image
       type: string
-    - default: ""
+    - default: "quay.io/kuadrant/internal-extensions:latest"
       description: Additional flags for helm install command, example '--set=kuadrant.installPlanApproval=Manual --set=kuadrant.startingCSV=kuadrant-operator.v1.2.0'
       name: additional-helm-flags
       type: string

--- a/pipelines/test/osd-upgrade/pipeline.yaml
+++ b/pipelines/test/osd-upgrade/pipeline.yaml
@@ -63,6 +63,10 @@ spec:
       name: gateway-crd
       type: string
     - default: ""
+      description: Extensions image to overwrite default one.
+      name: extensions-image
+      type: string
+    - default: ""
       description: Additional flags for helm install command, example '--set=kuadrant.installPlanApproval=Manual --set=kuadrant.startingCSV=kuadrant-operator.v1.2.0'
       name: additional-helm-flags
       type: string
@@ -368,6 +372,8 @@ spec:
           value: $(tasks.kubectl-login.results.kubeconfig-path)
         - name: gateway-crd
           value: $(params.gateway-crd)
+        - name: extensions-image
+          value: $(params.extensions-image)
         - name: additional-helm-flags
           value: $(params.additional-helm-flags)
         - name: additional-helm-tools-flags

--- a/pipelines/test/osd-upgrade/pipeline.yaml
+++ b/pipelines/test/osd-upgrade/pipeline.yaml
@@ -66,7 +66,7 @@ spec:
       description: Extensions image to overwrite default one.
       name: extensions-image
       type: string
-    - default: ""
+    - default: "quay.io/kuadrant/internal-extensions:latest"
       description: Additional flags for helm install command, example '--set=kuadrant.installPlanApproval=Manual --set=kuadrant.startingCSV=kuadrant-operator.v1.2.0'
       name: additional-helm-flags
       type: string

--- a/pipelines/test/osd-upgrade/pipeline.yaml
+++ b/pipelines/test/osd-upgrade/pipeline.yaml
@@ -62,11 +62,11 @@ spec:
       description: GatewayAPI CRD version. [v1.2.1, v1.3.0, v1.4.0] available; leave empty if installing on Openshift 4.19+.
       name: gateway-crd
       type: string
-    - default: ""
+    - default: "quay.io/kuadrant/internal-extensions:latest"
       description: Extensions image to overwrite default one.
       name: extensions-image
       type: string
-    - default: "quay.io/kuadrant/internal-extensions:latest"
+    - default: ""
       description: Additional flags for helm install command, example '--set=kuadrant.installPlanApproval=Manual --set=kuadrant.startingCSV=kuadrant-operator.v1.2.0'
       name: additional-helm-flags
       type: string

--- a/pipelines/test/osd/pipeline.yaml
+++ b/pipelines/test/osd/pipeline.yaml
@@ -63,6 +63,10 @@ spec:
       name: gateway-crd
       type: string
     - default: ""
+      description: Extensions image to overwrite default one.
+      name: extensions-image
+      type: string
+    - default: ""
       description: Additional flags for helm install command, example '--set=kuadrant.installPlanApproval=Manual --set=kuadrant.startingCSV=kuadrant-operator.v1.2.0'
       name: additional-helm-flags
       type: string
@@ -364,6 +368,8 @@ spec:
           value: $(tasks.kubectl-login.results.kubeconfig-path)
         - name: gateway-crd
           value: $(params.gateway-crd)
+        - name: extensions-image
+          value: $(params.extensions-image)
         - name: additional-helm-flags
           value: $(params.additional-helm-flags)
         - name: additional-helm-tools-flags

--- a/pipelines/test/osd/pipeline.yaml
+++ b/pipelines/test/osd/pipeline.yaml
@@ -66,7 +66,7 @@ spec:
       description: Extensions image to overwrite default one.
       name: extensions-image
       type: string
-    - default: ""
+    - default: "quay.io/kuadrant/internal-extensions:latest"
       description: Additional flags for helm install command, example '--set=kuadrant.installPlanApproval=Manual --set=kuadrant.startingCSV=kuadrant-operator.v1.2.0'
       name: additional-helm-flags
       type: string

--- a/pipelines/test/osd/pipeline.yaml
+++ b/pipelines/test/osd/pipeline.yaml
@@ -62,11 +62,11 @@ spec:
       description: GatewayAPI CRD version. [v1.2.1, v1.3.0, v1.4.0] available; leave empty if installing on Openshift 4.19+.
       name: gateway-crd
       type: string
-    - default: ""
+    - default: "quay.io/kuadrant/internal-extensions:latest"
       description: Extensions image to overwrite default one.
       name: extensions-image
       type: string
-    - default: "quay.io/kuadrant/internal-extensions:latest"
+    - default: ""
       description: Additional flags for helm install command, example '--set=kuadrant.installPlanApproval=Manual --set=kuadrant.startingCSV=kuadrant-operator.v1.2.0'
       name: additional-helm-flags
       type: string

--- a/pipelines/test/upgrade/pipeline.yaml
+++ b/pipelines/test/upgrade/pipeline.yaml
@@ -33,6 +33,10 @@ spec:
       description: GatewayAPI CRD version. [v1.2.1, v1.3.0, v1.4.0] available; leave empty if installing on Openshift 4.19+.
       name: gateway-crd
       type: string
+    - default: ""
+      description: Extensions image to overwrite default one.
+      name: extensions-image
+      type: string
     - default: "--set=kuadrant.installPlanApproval=Manual --set=kuadrant.startingCSV=rhcl-operator.v1.2.1"
       description: Additional flags for helm install command, update default value for desired "upgrade from" version here as needed
       name: additional-helm-flags
@@ -133,6 +137,8 @@ spec:
           value: $(tasks.kubectl-login.results.kubeconfig-path)
         - name: gateway-crd
           value: $(params.gateway-crd)
+        - name: extensions-image
+          value: $(params.extensions-image)
         - name: additional-helm-flags
           value: $(params.additional-helm-flags)
         - name: additional-helm-tools-flags

--- a/pipelines/test/upgrade/pipeline.yaml
+++ b/pipelines/test/upgrade/pipeline.yaml
@@ -33,7 +33,7 @@ spec:
       description: GatewayAPI CRD version. [v1.2.1, v1.3.0, v1.4.0] available; leave empty if installing on Openshift 4.19+.
       name: gateway-crd
       type: string
-    - default: ""
+    - default: "quay.io/kuadrant/internal-extensions:latest"
       description: Extensions image to overwrite default one.
       name: extensions-image
       type: string

--- a/tasks/deploy/helm-deploy.yaml
+++ b/tasks/deploy/helm-deploy.yaml
@@ -159,7 +159,7 @@ spec:
       helm install -n=default \
       --repo https://kuadrant.io/helm-charts-olm \
       --values=/mount/values-additional-manifests/additionalManifests.yaml \
-      --values=//mount/values-extensions-manifests/extensionsManifests.yaml \
+      --values=/mount/values-extensions-manifests/extensionsManifests.yaml \
       --set=kuadrant.indexImage="$(params.index-image)" \
       --set=kuadrant.channel="$(params.channel)" \
       --set=kuadrant.operatorName="$(params.operator-name)" \

--- a/tasks/deploy/helm-deploy.yaml
+++ b/tasks/deploy/helm-deploy.yaml
@@ -28,6 +28,9 @@ spec:
     - description: Additional flags for tools helm, example '--set=tools.keycloak.keycloakProvider=deployment --set=tools.valkey.enable=false'"
       name: additional-helm-tools-flags
       type: string
+    - description: Extensions image to overwrite default one.
+      name: extensions-image
+      type: string
   steps:
   # Uninstall steps first(cleanup before install)
   - name: remove-leftovers-kuadrant-ns
@@ -156,9 +159,11 @@ spec:
       helm install -n=default \
       --repo https://kuadrant.io/helm-charts-olm \
       --values=/mount/values-additional-manifests/additionalManifests.yaml \
+      --values=//mount/values-extensions-manifests/extensionsManifests.yaml \
       --set=kuadrant.indexImage="$(params.index-image)" \
       --set=kuadrant.channel="$(params.channel)" \
       --set=kuadrant.operatorName="$(params.operator-name)" \
+      --set=kuadrant.extensionsImage="$(params.extensions-image)" \
       --set=istio.istioProvider="$(params.istio-provider)" \
       --set=gatewayAPI.version="$(params.gateway-crd)" \
       --set=tools.enabled=true \
@@ -169,6 +174,8 @@ spec:
     volumeMounts:
       - mountPath: /mount/values-additional-manifests
         name: values-additional-manifests
+      - mountPath: /mount/values-extensions-manifests
+        name: values-extensions-manifests
     env:
       - name: KUBECONFIG
         value: $(params.kubeconfig-path)

--- a/tasks/deploy/helm-deploy.yaml
+++ b/tasks/deploy/helm-deploy.yaml
@@ -209,5 +209,9 @@ spec:
     - secret:
         secretName: values-additional-manifests
       name: values-additional-manifests
+    - configMap:
+        name: values-extensions-manifests
+      name: values-extensions-manifests
+      
   workspaces:
   - name: shared-workspace


### PR DESCRIPTION
Added extensions image parameter to match changes laid out here: https://github.com/Kuadrant/helm-charts-olm/pull/90

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable extensions-image parameter across deployment and test pipelines and the Helm deploy task, allowing the extensions image used during Helm deployments to be overridden. Defaults to quay.io/kuadrant/internal-extensions:latest.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/testsuite-pipelines/pull/168?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->