### PR TITLE
Infra migration refactor

### DIFF
--- a/pipelines/test/nightly/pipeline.yaml
+++ b/pipelines/test/nightly/pipeline.yaml
@@ -2,6 +2,8 @@ apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: test-nightly
+  annotations:
+    pipelinesascode.tekton.dev/coschedule: workspaces
 spec:
   params:
     - default: 'quay.io/kuadrant/testsuite:unstable'
@@ -147,6 +149,7 @@ spec:
       taskRef:
         kind: Task
         name: run-tests
+      onError: continue
       workspaces:
         - name: shared-workspace
     - name: run-tests-authorino-standalone
@@ -172,6 +175,7 @@ spec:
       taskRef:
         kind: Task
         name: run-tests
+      onError: continue
       workspaces:
         - name: shared-workspace
     - name: run-tests-ui
@@ -197,6 +201,7 @@ spec:
       taskRef:
         kind: Task
         name: run-tests
+      onError: continue
       workspaces:
         - name: shared-workspace
     - name: run-tests-dnstls-gcp
@@ -222,6 +227,7 @@ spec:
       taskRef:
         kind: Task
         name: run-tests
+      onError: continue
       workspaces:
         - name: shared-workspace
     - name: run-tests-multicluster
@@ -248,6 +254,7 @@ spec:
       taskRef:
         kind: Task
         name: run-tests
+      onError: continue
       workspaces:
         - name: shared-workspace
     - name: run-tests-dnstls-azure
@@ -273,6 +280,7 @@ spec:
       taskRef:
         kind: Task
         name: run-tests
+      onError: continue
       workspaces:
         - name: shared-workspace
     - name: run-tests-disruptive
@@ -298,6 +306,7 @@ spec:
       taskRef:
         kind: Task
         name: run-tests
+      onError: continue
       workspaces:
         - name: shared-workspace
   finally:

--- a/tasks/deploy/check-image-existence.yaml
+++ b/tasks/deploy/check-image-existence.yaml
@@ -17,10 +17,6 @@ spec:
       command:
         - /bin/sh
         - -cexv
-      computeResources:
-        limits:
-          cpu: '250m'
-          memory: 128Mi
       image: quay.io/kuadrant/testsuite-pipelines-tools:latest
       imagePullPolicy: Always
       name: check-image-existence

--- a/tasks/deploy/nightly-image-date.yaml
+++ b/tasks/deploy/nightly-image-date.yaml
@@ -12,10 +12,6 @@ spec:
       command:
         - /bin/sh
         - -c
-      computeResources:
-        limits:
-          cpu: '250m'
-          memory: 128Mi
       env:
         - name: TZ
           value: "Europe/Prague"

--- a/tasks/infra/cluster-secret-cleanup.yaml
+++ b/tasks/infra/cluster-secret-cleanup.yaml
@@ -8,11 +8,7 @@ spec:
     - name: cluster-name
       type: string
   steps:
-    - computeResources:
-        limits:
-          cpu: '100m'
-          memory: 64Mi
-      env:
+    - env:
         - name: NAMESPACE
           valueFrom:
             fieldRef:

--- a/tasks/infra/delete-aro.yaml
+++ b/tasks/infra/delete-aro.yaml
@@ -10,11 +10,7 @@ spec:
     - name: cluster-name
       type: string
   steps:
-    - computeResources:
-        limits:
-          cpu: '150m'
-          memory: 400Mi
-      env:
+    - env:
         - name: APP_ID
           valueFrom:
             secretKeyRef:

--- a/tasks/infra/delete-ocp-aws.yaml
+++ b/tasks/infra/delete-ocp-aws.yaml
@@ -12,11 +12,7 @@ spec:
       configMap:
         name: gitlab-ca
   steps:
-    - computeResources:
-        limits:
-          cpu: '150m'
-          memory: 400Mi
-      env:
+    - env:
         - name: NAMESPACE
           valueFrom:
             fieldRef:

--- a/tasks/infra/delete-osd.yaml
+++ b/tasks/infra/delete-osd.yaml
@@ -8,11 +8,7 @@ spec:
     - name: cluster-id
       description: cluster ID that OCM uses to identify the cluster
   steps:
-    - computeResources:
-        limits:
-          cpu: '100m'
-          memory: 64Mi
-      image: quay.io/kuadrant/testsuite-pipelines-tools:latest
+    - image: quay.io/kuadrant/testsuite-pipelines-tools:latest
       imagePullPolicy: Always
       name: delete-osd
       script: |

--- a/tasks/infra/delete-rosa.yaml
+++ b/tasks/infra/delete-rosa.yaml
@@ -12,11 +12,7 @@ spec:
     - name: region
       type: string
   steps:
-    - computeResources:
-        limits:
-          cpu: '100m'
-          memory: 64Mi
-      env:
+    - env:
         - name: AWS_ACCOUNT_ID
           valueFrom:
             secretKeyRef:

--- a/tasks/infra/do-custom-updates.yaml
+++ b/tasks/infra/do-custom-updates.yaml
@@ -9,10 +9,6 @@ spec:
       type: string
   steps:
     - name: do-custom-updates
-      computeResources:
-        limits:
-          cpu: '100m'
-          memory: 64Mi
       image: quay.io/kuadrant/testsuite-pipelines-tools:latest
       imagePullPolicy: Always
       env:

--- a/tasks/infra/get-cluster-id.yaml
+++ b/tasks/infra/get-cluster-id.yaml
@@ -11,11 +11,7 @@ spec:
     - name: cluster-id
       description: Cluster ID used in OCM/HCC
   steps:
-    - computeResources:
-        limits:
-          cpu: '100m'
-          memory: 64Mi
-      image: quay.io/kuadrant/testsuite-pipelines-tools:latest
+    - image: quay.io/kuadrant/testsuite-pipelines-tools:latest
       imagePullPolicy: Always
       name: get-cluster-id
       script: |

--- a/tasks/infra/get-osd-credentials.yaml
+++ b/tasks/infra/get-osd-credentials.yaml
@@ -25,11 +25,7 @@ spec:
     - name: cluster-id
       description: Identifier assinged to cluster by OCM/HCC
   steps:
-    - computeResources:
-        limits:
-          cpu: '100m'
-          memory: 64Mi
-      env:
+    - env:
         - name: NAMESPACE
           valueFrom:
             fieldRef:

--- a/tasks/infra/ocm-login.yaml
+++ b/tasks/infra/ocm-login.yaml
@@ -10,11 +10,7 @@ spec:
     - name: ocm-instance
       type: string
   steps:
-    - computeResources:
-        limits:
-          cpu: '100m'
-          memory: 64Mi
-      env:
+    - env:
         - name: CLIENT_ID
           valueFrom:
             secretKeyRef:

--- a/tasks/infra/operator-pod-restart.yaml
+++ b/tasks/infra/operator-pod-restart.yaml
@@ -8,11 +8,7 @@ spec:
     - name: kubeconfig-path
       type: string
   steps:
-    - computeResources:
-        limits:
-          cpu: '100m'
-          memory: 128Mi
-      env:
+    - env:
         - name: KUBECONFIG
           value: $(params.kubeconfig-path)
       image: quay.io/kuadrant/testsuite-pipelines-tools:latest

--- a/tasks/infra/parameter-sanity-check.yaml
+++ b/tasks/infra/parameter-sanity-check.yaml
@@ -27,11 +27,7 @@ spec:
     - name: create-cmd-flags
       description: Flags for cluster creation command
   steps:
-    - computeResources:
-        limits:
-          cpu: '100m'
-          memory: 64Mi
-      env:
+    - env:
         - name: NAMESPACE
           valueFrom:
             fieldRef:

--- a/tasks/infra/pause-pipeline.yaml
+++ b/tasks/infra/pause-pipeline.yaml
@@ -6,10 +6,6 @@ spec:
   description: 'Pause the pipeline when "pause-pipeline" ConfigMap exists with ".data.pause: true"'
   steps:
     - name: pause-pipeline
-      computeResources:
-        limits:
-          cpu: '100m'
-          memory: 64Mi
       image: quay.io/kuadrant/testsuite-pipelines-tools:latest
       imagePullPolicy: Always
       env:

--- a/tasks/infra/prepare-for-rhcl-rc-install.yaml
+++ b/tasks/infra/prepare-for-rhcl-rc-install.yaml
@@ -8,11 +8,7 @@ spec:
     - name: kubeconfig-path
       type: string
   steps:
-    - computeResources:
-        limits:
-          cpu: '200m'
-          memory: 256Mi
-      env:
+    - env:
         - name: KUBECONFIG
           value: $(params.kubeconfig-path)
         - name: ADDITIONAL_AUTH_ENTRIES

--- a/tasks/infra/provision-aro.yaml
+++ b/tasks/infra/provision-aro.yaml
@@ -29,11 +29,7 @@ spec:
     - name: credentials-secret
       description: secret name with credentials
   steps:
-    - computeResources:
-        limits:
-          cpu: '150m'
-          memory: 400Mi
-      env:
+    - env:
         - name: APP_ID
           valueFrom:
             secretKeyRef:

--- a/tasks/infra/provision-ocp-aws.yaml
+++ b/tasks/infra/provision-ocp-aws.yaml
@@ -37,12 +37,9 @@ spec:
         name: gitlab-ca
   steps:
     - computeResources:
-        limits:
-          cpu: '2000m'        # 2 CPU cores
-          memory: '4Gi'        # 4GB RAM
         requests:
-          cpu: '1000m'        # 1 CPU core  
-          memory: '2Gi'        # 2GB RAM
+          cpu: '1'
+          memory: 1Gi
       env:
         - name: NAMESPACE
           valueFrom:

--- a/tasks/infra/provision-osd-aws.yaml
+++ b/tasks/infra/provision-osd-aws.yaml
@@ -19,11 +19,7 @@ spec:
     - name: cluster-id
       description: cluster ID that OCM uses to identify the cluster
   steps:
-    - computeResources:
-        limits:
-          cpu: '100m'
-          memory: 64Mi
-      env:
+    - env:
         - name: AWS_ACCOUNT_ID
           valueFrom:
             secretKeyRef:

--- a/tasks/infra/provision-osd-gcp.yaml
+++ b/tasks/infra/provision-osd-gcp.yaml
@@ -19,11 +19,7 @@ spec:
     - name: cluster-id
       description: cluster ID that OCM uses to identify the cluster
   steps:
-    - computeResources:
-        limits:
-          cpu: '100m'
-          memory: 64Mi
-      env:
+    - env:
         - name: SERVICE_ACCOUNT_FILE
           valueFrom:
             secretKeyRef:

--- a/tasks/infra/provision-rosa.yaml
+++ b/tasks/infra/provision-rosa.yaml
@@ -21,11 +21,7 @@ spec:
     - name: cluster-id
       description: cluster ID that OCM uses to identify the cluster
   steps:
-    - computeResources:
-        limits:
-          cpu: '100m'
-          memory: 64Mi
-      env:
+    - env:
         - name: AWS_ACCOUNT_ID
           valueFrom:
             secretKeyRef:

--- a/tasks/infra/rosa-login.yaml
+++ b/tasks/infra/rosa-login.yaml
@@ -14,11 +14,7 @@ spec:
     - name: region
       type: string
   steps:
-    - computeResources:
-        limits:
-          cpu: '100m'
-          memory: 64Mi
-      env:
+    - env:
         - name: CLIENT_ID
           valueFrom:
             secretKeyRef:

--- a/tasks/infra/upgrade-to-latest.yaml
+++ b/tasks/infra/upgrade-to-latest.yaml
@@ -8,11 +8,7 @@ spec:
     - name: kubeconfig-path
       type: string
   steps:
-    - computeResources:
-        limits:
-          cpu: '100m'
-          memory: 128Mi
-      env:
+    - env:
         - name: KUBECONFIG
           value: $(params.kubeconfig-path)
       image: quay.io/kuadrant/testsuite-pipelines-tools:latest

--- a/tasks/infra/wait-for-valid-certificates.yaml
+++ b/tasks/infra/wait-for-valid-certificates.yaml
@@ -10,11 +10,7 @@ spec:
     - name: api-url
       type: string
   steps:
-    - computeResources:
-        limits:
-          cpu: '100m'
-          memory: 64Mi
-      image: quay.io/kuadrant/testsuite-pipelines-tools:latest
+    - image: quay.io/kuadrant/testsuite-pipelines-tools:latest
       imagePullPolicy: Always
       name: wait-for-valid-certificates
       script: |

--- a/tasks/infra/wait-till-osd-is-deleted.yaml
+++ b/tasks/infra/wait-till-osd-is-deleted.yaml
@@ -8,11 +8,7 @@ spec:
     - name: cluster-id
       type: string
   steps:
-    - computeResources:
-        limits:
-          cpu: '100m'
-          memory: 64Mi
-      image: quay.io/kuadrant/testsuite-pipelines-tools:latest
+    - image: quay.io/kuadrant/testsuite-pipelines-tools:latest
       imagePullPolicy: Always
       name: wait-till-osd-is-deleted
       script: |

--- a/tasks/infra/wait-till-osd-is-ready.yaml
+++ b/tasks/infra/wait-till-osd-is-ready.yaml
@@ -8,11 +8,7 @@ spec:
     - name: cluster-id
       type: string
   steps:
-    - computeResources:
-        limits:
-          cpu: '100m'
-          memory: 64Mi
-      image: quay.io/kuadrant/testsuite-pipelines-tools:latest
+    - image: quay.io/kuadrant/testsuite-pipelines-tools:latest
       imagePullPolicy: Always
       name: wait-till-osd-is-ready
       script: |

--- a/tasks/login/kubectl-login.yaml
+++ b/tasks/login/kubectl-login.yaml
@@ -26,7 +26,8 @@ spec:
         set -vo pipefail
 
         export CLUSTER_NAME=$(echo $(params.kube-api) | sed 's/.*api\.\([^\.]*\).*/\1/')
-        export KUBECONFIG=$(workspaces.shared-workspace.path)/${CLUSTER_NAME}
+        mkdir -p $(workspaces.shared-workspace.path)/kubeconfigs
+        export KUBECONFIG=$(workspaces.shared-workspace.path)/kubeconfigs/${CLUSTER_NAME}
         export OAUTH_URL=$(echo $(params.kube-api) | sed -e 's/api/oauth-openshift.apps/' -e 's/\(.*\):.*/\1/')/oauth/authorize
         export TOKEN=$(curl -XPOST -kis --data response_type=token --data client_id=openshift-challenging-client -u ${KUBE_USER}:${KUBE_PASSWORD} ${OAUTH_URL} | grep "Location:" | sed 's/.*access_token=\([^&]*\).*/\1/')
         echo -n ${TOKEN} | tee $(results.token.path)
@@ -39,10 +40,6 @@ spec:
         echo -n ${KUBECONFIG} | tee $(results.kubeconfig-path.path)
         export OCP_VERSION=$(kubectl get clusterversion -o jsonpath='{.items[].status.history[0].version}')
         echo -n ${OCP_VERSION%.*} | tee $(results.ocp-version.path)
-      computeResources:
-        limits:
-          cpu: '250m'
-          memory: 128Mi
       env:
         - name: WORKSPACE
           value: $(workspaces.shared-workspace.path)

--- a/tasks/misc/clone-rapidast-repo.yaml
+++ b/tasks/misc/clone-rapidast-repo.yaml
@@ -20,10 +20,6 @@ spec:
     command:
       - /bin/bash
       - -c
-    computeResources:
-      limits:
-        cpu: 250m
-        memory: 128Mi
     image: quay.io/kuadrant/testsuite-pipelines-tools:latest
     imagePullPolicy: Always
   workspaces:

--- a/tasks/misc/compose-config-file.yaml
+++ b/tasks/misc/compose-config-file.yaml
@@ -18,11 +18,7 @@ spec:
         secretName: rapidast-storage-access-key
       name: rapidast-storage-access-key
   steps:
-    - computeResources:
-        limits:
-          cpu: '100m'
-          memory: 64Mi
-      image: quay.io/kuadrant/testsuite-pipelines-tools:latest
+    - image: quay.io/kuadrant/testsuite-pipelines-tools:latest
       imagePullPolicy: Always
       name: compose-config-file
       volumeMounts:

--- a/tasks/misc/rapidast-cleanup.yaml
+++ b/tasks/misc/rapidast-cleanup.yaml
@@ -7,11 +7,7 @@ spec:
   workspaces:
     - name: shared-workspace
   steps:
-    - computeResources:
-        limits:
-          cpu: '100m'
-          memory: 64Mi
-      image: quay.io/kuadrant/testsuite-pipelines-tools:latest
+    - image: quay.io/kuadrant/testsuite-pipelines-tools:latest
       imagePullPolicy: Always
       env:
         - name: NAMESPACE

--- a/tasks/misc/rapidast-scan.yaml
+++ b/tasks/misc/rapidast-scan.yaml
@@ -7,11 +7,7 @@ spec:
   workspaces:
     - name: shared-workspace
   steps:
-    - computeResources:
-        limits:
-          cpu: '100m'
-          memory: 64Mi
-      image: quay.io/kuadrant/testsuite-pipelines-tools:latest
+    - image: quay.io/kuadrant/testsuite-pipelines-tools:latest
       imagePullPolicy: Always
       name: rapidast-scan
       script: |

--- a/tasks/misc/wait-for-job-to-complete.yaml
+++ b/tasks/misc/wait-for-job-to-complete.yaml
@@ -9,10 +9,6 @@ spec:
       type: string
   steps:
     - name: wait-for-job-to-complete
-      computeResources:
-        limits:
-          cpu: '100m'
-          memory: 64Mi
       image: quay.io/kuadrant/testsuite-pipelines-tools:latest
       imagePullPolicy: Always
       env:

--- a/tasks/test/collect-info.yaml
+++ b/tasks/test/collect-info.yaml
@@ -27,10 +27,6 @@ spec:
         - /bin/bash
         - -cveo
         - pipefail
-      computeResources:
-        limits:
-          cpu: '250m'
-          memory: 256Mi
       env:
         - name: KUBECONFIG
           value: $(params.kubeconfig-path)

--- a/tasks/test/rptool-upload.yaml
+++ b/tasks/test/rptool-upload.yaml
@@ -27,10 +27,6 @@ spec:
         - /bin/bash
         - -cveo
         - pipefail
-      computeResources:
-        limits:
-          cpu: '250m'
-          memory: 256Mi
       env:
         - name: WORKSPACE
           value: $(workspaces.shared-workspace.path)

--- a/tasks/test/run-tests.yaml
+++ b/tasks/test/run-tests.yaml
@@ -38,12 +38,9 @@ spec:
         - -cveo
         - pipefail
       computeResources:
-        limits:
-          cpu: '2'
-          memory: 2500Mi
         requests:
           cpu: '1'
-          memory: 2000Mi
+          memory: 1Gi
       env:
         - name: KUBECONFIG
           value: $(params.kubeconfig-path)
@@ -64,6 +61,7 @@ spec:
       image: $(params.testsuite-image)
       imagePullPolicy: Always
       name: run-tests
+      timeout: 2h
       volumeMounts:
         - mountPath: /var/kuadrant-settings
           name: $(params.settings-cm)


### PR DESCRIPTION
### Changes summary
- `pipelinesascode.tekton.dev/coschedule: workspaces` annotation on nightly pipeline, hardcoding tasks coscheduling for nightly pipelines as it is not possible to configure globally on the new tenant
- `onError: continue` on nightly testing tasks, ensuring pipeline continue running even if one of the targets fail
- remove limits resources definitions on all the tasks, instead they will be globally defined with `LimitRange` CR on the new tenant, and on the existing ocp clusters before the migration happens: 
```yaml
apiVersion: v1
kind: LimitRange
metadata:
  name: kuadrant-pipelines-limits
spec:
  limits:
    - default:
        cpu: "2"
        memory: 2Gi
      defaultRequest:
        cpu: 200m
        memory: 256Mi
      type: Container
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pipelines now continue past failing test tasks so nightly runs complete and later steps still run.
  * Nightly image generation now respects Europe/Prague timezone.

* **Bug Fixes**
  * Added a timeout for long-running test steps to avoid indefinite runs.

* **Chores**
  * Streamlined resource declarations across pipeline tasks.
  * Kubeconfig handling updated to use a dedicated per-cluster kubeconfig directory.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/testsuite-pipelines/pull/169)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->