### PR TITLE
feat: add Go installation to pipeline tools image

### DIFF
--- a/init-container.sh
+++ b/init-container.sh
@@ -34,6 +34,12 @@ curl -LSs -o /usr/local/bin/cli53 "https://github.com/barnybug/cli53/releases/do
     | jq -r .tag_name)/cli53-linux-${ARCH}" \
     && chmod 0755 /usr/local/bin/cli53
 
+GO_VERSION=$(curl -Lfs 'https://go.dev/VERSION?m=text' | head -n1) \
+    && curl -Lfs "https://go.dev/dl/${GO_VERSION}.linux-${ARCH}.tar.gz" | \
+    tar -xz -f - -C /usr/local \
+    && ln -s /usr/local/go/bin/go /usr/local/bin/go \
+    && ln -s /usr/local/go/bin/gofmt /usr/local/bin/gofmt
+
 NODE_VERSION=$(curl -Lfs https://nodejs.org/dist/index.json | jq -r '[.[] | select(.lts != false)][0].version') \
     && curl -Lfs "https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" | \
     tar -xJ -f - --strip-components=1 -C /usr/local


### PR DESCRIPTION
### Summary

Add dynamic Go installation to init-container.sh to support MCP Gateway E2E tests that require Go toolchain. The installation fetches the latest stable Go version and creates symlinks to make go and gofmt available in the PATH.

### Verification

Build the container image locally:
```bash
podman build -f Containerfile -t test-image .
```
Verify go is available:
```bash
podman run --rm test-image go version
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- The initialisation container now automatically downloads and installs the Go language toolchain at build time, dynamically selecting the appropriate version and architecture-specific binaries for your system. Go development tools are now immediately available within the container environment without requiring manual setup or configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/testsuite-pipelines/pull/170)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->