### PR TITLE
feat: add ReportPortal integration to MCP gateway pipelines

### DIFF
--- a/pipelines/test/mcp-gateway-osd/kustomization.yaml
+++ b/pipelines/test/mcp-gateway-osd/kustomization.yaml
@@ -11,6 +11,7 @@ components:
   - ../../../tasks/deploy/
   - ../../../tasks/infra/
   - ../../../tasks/misc/
+  - ../../../tasks/test/
   - ../../../tasks/test/mcp/
 
 resources:

--- a/pipelines/test/mcp-gateway-osd/pipeline.yaml
+++ b/pipelines/test/mcp-gateway-osd/pipeline.yaml
@@ -125,6 +125,31 @@ spec:
     name: additional-manifests-secret
     type: string
     default: values-additional-manifests
+# Report Portal
+  - description: Prefix of the launch name saved in Report Portal (nightly, pipeline, etc.)
+    name: launch-name
+    type: string
+    default: pipeline
+  - description: Optional launch description for Report Portal
+    name: launch-description
+    type: string
+    default: "MCP Gateway Testing"
+  - description: Report Portal Project to store test results (e.g. testsuite, nightly-testsuite)
+    name: rp-project
+    type: string
+    default: mcp-gateway
+  - description: Upload test results to Report Portal (true/false)
+    name: upload-results
+    type: string
+    default: "false"
+  - description: rptool image for uploading results to Report Portal
+    name: rptool-image
+    type: string
+    default: "quay.io/kuadrant/rptool:unstable"
+  - description: Used as launch name suffix in Report Portal
+    name: make-target
+    type: string
+    default: mcp-gateway
 # Tests
   - description: Run MCP e2e tests (true/false)
     name: run-e2e-tests
@@ -586,3 +611,26 @@ spec:
     taskRef:
       kind: Task
       name: cluster-secret-cleanup
+  finally:
+  - name: rptool-upload
+    when:
+      - input: $(params.upload-results)
+        operator: in
+        values: ["true"]
+    params:
+      - name: launch-name
+        value: $(params.launch-name)
+      - name: launch-description
+        value: $(params.launch-description)
+      - name: rptool-image
+        value: $(params.rptool-image)
+      - name: make-target
+        value: $(params.make-target)
+      - name: rp-project
+        value: $(params.rp-project)
+    taskRef:
+      kind: Task
+      name: rptool-upload
+    workspaces:
+      - name: shared-workspace
+        workspace: shared-workspace

--- a/pipelines/test/mcp-gateway/kustomization.yaml
+++ b/pipelines/test/mcp-gateway/kustomization.yaml
@@ -10,6 +10,7 @@ components:
   - ../../../tasks/login/
   - ../../../tasks/deploy/
   - ../../../tasks/misc/
+  - ../../../tasks/test/
   - ../../../tasks/test/mcp/
 
 resources:

--- a/pipelines/test/mcp-gateway/pipeline.yaml
+++ b/pipelines/test/mcp-gateway/pipeline.yaml
@@ -91,6 +91,31 @@ spec:
     name: extensions-image
     type: string
     default: "quay.io/kuadrant/internal-extensions:latest"
+# Report Portal
+  - description: Prefix of the launch name saved in Report Portal (nightly, pipeline, etc.)
+    name: launch-name
+    type: string
+    default: pipeline
+  - description: Optional launch description for Report Portal
+    name: launch-description
+    type: string
+    default: "MCP Gateway Testing"
+  - description: Report Portal Project to store test results (e.g. testsuite, nightly-testsuite)
+    name: rp-project
+    type: string
+    default: mcp-gateway
+  - description: Upload test results to Report Portal (true/false)
+    name: upload-results
+    type: string
+    default: "false"
+  - description: rptool image for uploading results to Report Portal
+    name: rptool-image
+    type: string
+    default: "quay.io/kuadrant/rptool:unstable"
+  - description: Used as launch name suffix in Report Portal
+    name: make-target
+    type: string
+    default: mcp-gateway
 # Tests
   - description: Run MCP e2e tests (true/false)
     name: run-e2e-tests
@@ -321,5 +346,28 @@ spec:
     workspaces:
     - name: shared-workspace
       workspace: shared-workspace
+  finally:
+  - name: rptool-upload
+    when:
+      - input: $(params.upload-results)
+        operator: in
+        values: ["true"]
+    params:
+      - name: launch-name
+        value: $(params.launch-name)
+      - name: launch-description
+        value: $(params.launch-description)
+      - name: rptool-image
+        value: $(params.rptool-image)
+      - name: make-target
+        value: $(params.make-target)
+      - name: rp-project
+        value: $(params.rp-project)
+    taskRef:
+      kind: Task
+      name: rptool-upload
+    workspaces:
+      - name: shared-workspace
+        workspace: shared-workspace
   workspaces:
   - name: shared-workspace

--- a/tasks/test/mcp/run-auth-e2e-tests.yaml
+++ b/tasks/test/mcp/run-auth-e2e-tests.yaml
@@ -63,7 +63,7 @@ spec:
 
         cd "$(workspaces.shared-workspace.path)/mcp-gateway"
 
-        # Install ginkgo test 
+        # Install ginkgo test dependencies
         make test-e2e-deps
 
         # deploy and register test MCP servers
@@ -257,7 +257,20 @@ spec:
         ]'
 
         if [ "$(params.run-tests)" = "true" ]; then
-          ./bin/ginkgo -v --tags=e2e --timeout="$E2E_TIMEOUT" --focus="AuthPolicy" ./tests/e2e
+          GINKGO_RC=0
+          ./bin/ginkgo -v --tags=e2e --timeout="$E2E_TIMEOUT" --procs="$E2E_PROCS" --junit-report="junit-e2e-auth-report.xml" --output-dir="$(workspaces.shared-workspace.path)" --focus="AuthPolicy" ./tests/e2e || GINKGO_RC=$?
+          REPORT="$(workspaces.shared-workspace.path)/junit-e2e-auth-report.xml"
+          # Clean up Ginkgo JUnit XML for ReportPortal:
+          #  - Remove BeforeSuite/AfterSuite entries (not real tests, one per parallel proc)
+          #  - Remove <properties> block (Ginkgo metadata that causes RP to silently fail suite creation)
+          #  - Rename testsuite/classname so tests appear grouped under 'e2e-auth' in RP
+          if [ -f "$REPORT" ]; then
+            sed -i -e '/<testcase name="\[Synchronized\(Before\|After\)Suite\]"/,/<\/testcase>/d' \
+                   -e '/<properties>/,/<\/properties>/d' \
+                   -e 's/<testsuite name="[^"]*"/<testsuite name="e2e-auth"/' \
+                   -e 's/classname="[^"]*"/classname="tests.e2e.auth"/g' "$REPORT"
+          fi
+          exit $GINKGO_RC
         else
           echo "Skipping auth e2e test execution (run-tests=false)"
         fi

--- a/tasks/test/mcp/run-conformance-tests.yaml
+++ b/tasks/test/mcp/run-conformance-tests.yaml
@@ -66,12 +66,15 @@ spec:
           tools-call-with-progress
         )
 
+        CONFORMANCE_RESULTS="$(workspaces.shared-workspace.path)/conformance-results"
+
         FAILED_SCENARIOS=()
         for scenario in "${SCENARIOS[@]}"; do
           echo "=== Running scenario: $scenario ==="
           if ! npx @modelcontextprotocol/conformance@${CONFORMANCE_VERSION} server \
             --url "${MCP_GATEWAY_URL}" \
             --scenario "$scenario" \
+            --output-dir "$CONFORMANCE_RESULTS" \
             --verbose; then
             echo "FAILED: $scenario"
             FAILED_SCENARIOS+=("$scenario")
@@ -80,6 +83,50 @@ spec:
           fi
           sleep 20
         done
+
+        # Generate JUnit XML report from conformance check results
+        JUNIT_REPORT="$(workspaces.shared-workspace.path)/junit-conformance-report.xml"
+        TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%S)"
+
+        if ! find "$CONFORMANCE_RESULTS" -name 'checks.json' 2>/dev/null | grep -q .; then
+          echo "ERROR: No checks.json files found under $CONFORMANCE_RESULTS"
+          exit 1
+        fi
+
+        # Merge all checks.json files into a single JSON array
+        echo "=== Generating JUnit XML report from checks.json files ==="
+        MERGED_CHECKS=$(find "$CONFORMANCE_RESULTS" -name 'checks.json' -print0 | xargs -0 jq -s 'add')
+
+        # Count totals for the testsuite element
+        TOTAL=$(echo "$MERGED_CHECKS" | jq 'length')
+        FAILURES=$(echo "$MERGED_CHECKS" | jq '[.[] | select(.status == "FAILURE")] | length')
+        SKIPPED=$(echo "$MERGED_CHECKS" | jq '[.[] | select(.status == "SKIPPED")] | length')
+
+        # Generate JUnit XML header
+        {
+          echo '<?xml version="1.0" encoding="UTF-8"?>'
+          echo '<testsuites>'
+          echo "  <testsuite name=\"mcp-conformance\" tests=\"${TOTAL}\" failures=\"${FAILURES}\" skipped=\"${SKIPPED}\" time=\"0\" timestamp=\"${TIMESTAMP}\">"
+
+          # Generate a <testcase> element for each check result
+          echo "$MERGED_CHECKS" | jq -r '
+            def esc: gsub("&";"&amp;") | gsub("<";"&lt;") | gsub(">";"&gt;") | gsub("\"";"&quot;");
+            .[] |
+            "    <testcase name=\"\(.id | esc)\" classname=\"tests.conformance\" time=\"0\">" +
+            (if .status == "FAILURE" then
+              "\n      <failure message=\"\((.errorMessage // "check failed") | esc)\">" +
+              (if .logs then (.logs | join("\n") | esc) else "" end) +
+              "</failure>"
+            elif .status == "SKIPPED" then
+              "\n      <skipped/>"
+            else "" end) +
+            "\n    </testcase>"
+          '
+
+          echo '  </testsuite>'
+          echo '</testsuites>'
+        } > "$JUNIT_REPORT"
+        echo "JUnit XML report written to $JUNIT_REPORT"
 
         if [ ${#FAILED_SCENARIOS[@]} -gt 0 ]; then
           echo ""

--- a/tasks/test/mcp/run-e2e-tests.yaml
+++ b/tasks/test/mcp/run-e2e-tests.yaml
@@ -75,6 +75,9 @@ spec:
 
         cd "$(workspaces.shared-workspace.path)/mcp-gateway"
 
+        # Install ginkgo test dependencies
+        make test-e2e-deps
+
         # deploy and register test MCP servers
         oc apply -k config/test-servers/
         # patch imagePullPolicy to pull the image from remote registry
@@ -299,7 +302,20 @@ spec:
         EOF
 
         if [ "$(params.run-tests)" = "true" ]; then
-          make test-e2e-run
+          GINKGO_RC=0
+          ./bin/ginkgo -v --tags=e2e --timeout="$E2E_TIMEOUT" --procs="$E2E_PROCS" --junit-report="junit-e2e-report.xml" --output-dir="$(workspaces.shared-workspace.path)" ./tests/e2e || GINKGO_RC=$?
+          REPORT="$(workspaces.shared-workspace.path)/junit-e2e-report.xml"
+          # Clean up Ginkgo JUnit XML for ReportPortal:
+          #  - Remove BeforeSuite/AfterSuite entries (not real tests, one per parallel proc)
+          #  - Remove <properties> block (Ginkgo metadata that causes RP to silently fail suite creation)
+          #  - Rename testsuite/classname so tests appear grouped under 'e2e' in RP
+          if [ -f "$REPORT" ]; then
+            sed -i -e '/<testcase name="\[Synchronized\(Before\|After\)Suite\]"/,/<\/testcase>/d' \
+                   -e '/<properties>/,/<\/properties>/d' \
+                   -e 's/<testsuite name="[^"]*"/<testsuite name="e2e"/' \
+                   -e 's/classname="[^"]*"/classname="tests.e2e"/g' "$REPORT"
+          fi
+          exit $GINKGO_RC
         else
           echo "Skipping e2e test execution (run-tests=false), but setup completed successfully"
         fi


### PR DESCRIPTION
## Summary
Adds JUnit XML report generation to all three MCP Gateway test tasks (e2e, auth-e2e, conformance) and integrates ReportPortal upload into both MCP Gateway pipelines (standard and OSD), enabling test result tracking alongside existing Kuadrant test pipelines.

## Changes
- Update pipeline kustomizations to include 'tasks/test/' component making 'rptool-upload' task available.
- Declare standard ReportPortal launch and target parameters in mcp-gateway and mcp-gateway-osd pipelines.
- Add 'rptool-upload' task to the 'finally' pipeline execution block.
- Refactor 'run-auth-e2e-tests' and 'run-e2e-tests' tasks to run Ginkgo with JUnit report generation enabled, and strip Ginkgo-specific suite metadata to prevent ReportPortal parsing failures.
- Implement JUnit XML generation inside 'run-conformance-tests' task by aggregating 'checks.json' outputs.

## Verification Steps
Eye review should be enough, this pipeline is scheduled nightly and I will work on hardening in coming days anyway. You can take a look at `test-mcp-gateway-*` PipelineRuns in kua-hub to see this in action. And the uploaded results in our RP instance (I created a new 'MCP Gateway' project for this).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Report Portal result uploads to MCP Gateway test pipelines, configurable through launch, project and upload settings.
  * Test pipelines now generate and share standardised JUnit reports for end-to-end and conformance testing.

* **Improvements**
  * Enhanced test reporting with clearer suite grouping and removal of non-test metadata.
  * Conformance results now include consolidated failures, skips and diagnostic logs.
  * Test failures continue to be reported accurately after result processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->