### PR TITLE
Explicitly set kubeconfigs for multicluster and disruptive tasks

### DIFF
--- a/pipelines/test/nightly/pipeline.yaml
+++ b/pipelines/test/nightly/pipeline.yaml
@@ -237,7 +237,7 @@ spec:
         - name: pytest-flags
           value: $(params.pytest-flags)
         - name: additional-env
-          value: '$(params.additional-env) KUADRANT_CONTROL_PLANE__cluster2__kubeconfig_path=$(tasks.kubectl-login-third-cluster.results.kubeconfig-path)'
+          value: '$(params.additional-env) KUADRANT_CONTROL_PLANE__cluster__kubeconfig_path=$(tasks.kubectl-login-second-cluster.results.kubeconfig-path) KUADRANT_CONTROL_PLANE__cluster2__kubeconfig_path=$(tasks.kubectl-login-third-cluster.results.kubeconfig-path)'
         - name: kubeconfig-path
           value: $(tasks.kubectl-login-second-cluster.results.kubeconfig-path)
         - name: cluster-credentials
@@ -288,7 +288,7 @@ spec:
         - name: settings-cm
           value: $(params.settings-cm)
         - name: additional-env
-          value: '$(params.additional-env) KUADRANT_CONTROL_PLANE__cluster2__kubeconfig_path=$(tasks.kubectl-login-third-cluster.results.kubeconfig-path)'
+          value: '$(params.additional-env) KUADRANT_CONTROL_PLANE__cluster__kubeconfig_path=$(tasks.kubectl-login-second-cluster.results.kubeconfig-path) KUADRANT_CONTROL_PLANE__cluster2__kubeconfig_path=$(tasks.kubectl-login-third-cluster.results.kubeconfig-path)'
         - name: kubeconfig-path
           value: $(tasks.kubectl-login-second-cluster.results.kubeconfig-path)
         - name: cluster-credentials

--- a/pipelines/test/release/pipeline.yaml
+++ b/pipelines/test/release/pipeline.yaml
@@ -227,7 +227,7 @@ spec:
         - name: pytest-flags
           value: $(params.pytest-flags)
         - name: additional-env
-          value: '$(params.additional-env) KUADRANT_CONTROL_PLANE__cluster2__kubeconfig_path=$(tasks.kubectl-login-second-cluster.results.kubeconfig-path)'
+          value: '$(params.additional-env) KUADRANT_CONTROL_PLANE__cluster__kubeconfig_path=$(tasks.kubectl-login.results.kubeconfig-path) KUADRANT_CONTROL_PLANE__cluster2__kubeconfig_path=$(tasks.kubectl-login-second-cluster.results.kubeconfig-path)'
         - name: kubeconfig-path
           value: $(tasks.kubectl-login.results.kubeconfig-path)
         - name: cluster-credentials
@@ -306,7 +306,7 @@ spec:
         - name: pytest-flags
           value: "$(params.pytest-flags) --junitxml=$(workspaces.shared-workspace.path)/junit-multicluster-gcp.xml -o junit_suite_name=multicluster-gcp"
         - name: additional-env
-          value: '$(params.additional-env) KUADRANT_CONTROL_PLANE__cluster2__kubeconfig_path=$(tasks.kubectl-login-second-cluster.results.kubeconfig-path) KUADRANT_CONTROL_PLANE__provider_secret=gcp-credentials KUADRANT_DNS__dns_server__geo_code=us-central1 KUADRANT_DNS__dns_server2__geo_code=europe-central2'
+          value: '$(params.additional-env) KUADRANT_CONTROL_PLANE__cluster__kubeconfig_path=$(tasks.kubectl-login.results.kubeconfig-path) KUADRANT_CONTROL_PLANE__cluster2__kubeconfig_path=$(tasks.kubectl-login-second-cluster.results.kubeconfig-path) KUADRANT_CONTROL_PLANE__provider_secret=gcp-credentials KUADRANT_DNS__dns_server__geo_code=us-central1 KUADRANT_DNS__dns_server2__geo_code=europe-central2'
         - name: kubeconfig-path
           value: $(tasks.kubectl-login.results.kubeconfig-path)
         - name: cluster-credentials
@@ -333,7 +333,7 @@ spec:
         - name: pytest-flags
           value: "$(params.pytest-flags) --junitxml=$(workspaces.shared-workspace.path)/junit-multicluster-azure.xml -o junit_suite_name=multicluster-azure"
         - name: additional-env
-          value: '$(params.additional-env) KUADRANT_CONTROL_PLANE__cluster2__kubeconfig_path=$(tasks.kubectl-login-second-cluster.results.kubeconfig-path) KUADRANT_CONTROL_PLANE__provider_secret=azure-credentials KUADRANT_DNS__dns_server__geo_code=GEO-NA KUADRANT_DNS__dns_server2__geo_code=GEO-EU'
+          value: '$(params.additional-env) KUADRANT_CONTROL_PLANE__cluster__kubeconfig_path=$(tasks.kubectl-login.results.kubeconfig-path) KUADRANT_CONTROL_PLANE__cluster2__kubeconfig_path=$(tasks.kubectl-login-second-cluster.results.kubeconfig-path) KUADRANT_CONTROL_PLANE__provider_secret=azure-credentials KUADRANT_DNS__dns_server__geo_code=GEO-NA KUADRANT_DNS__dns_server2__geo_code=GEO-EU'
         - name: kubeconfig-path
           value: $(tasks.kubectl-login.results.kubeconfig-path)
         - name: cluster-credentials
@@ -359,7 +359,7 @@ spec:
         - name: settings-cm
           value: $(params.settings-cm)
         - name: additional-env
-          value: '$(params.additional-env) KUADRANT_CONTROL_PLANE__cluster2__kubeconfig_path=$(tasks.kubectl-login-second-cluster.results.kubeconfig-path)'
+          value: '$(params.additional-env) KUADRANT_CONTROL_PLANE__cluster__kubeconfig_path=$(tasks.kubectl-login.results.kubeconfig-path) KUADRANT_CONTROL_PLANE__cluster2__kubeconfig_path=$(tasks.kubectl-login-second-cluster.results.kubeconfig-path)'
         - name: kubeconfig-path
           value: $(tasks.kubectl-login.results.kubeconfig-path)
         - name: cluster-credentials


### PR DESCRIPTION
### Summary
Explicitly set the primary cluster's kubeconfig_path in the additional-env for multicluster and disruptive pipeline tasks in both nightly and release pipelines. 

### Context
Previously, the first cluster for the tests (`control_plane.cluster`) relied solely on the container-level KUBECONFIG env var set by `run-tests.yaml`, while cluster2 had its kubeconfig_path explicitly configured via Dynaconf env vars. This caused the DNS failover test (Kuadrant/testsuite#1020) to fail in CI because kubectl_dns builds its own environment from `cluster.kubeconfig_path` rather than inheriting the container's KUBECONFIG, resulting in a None kubeconfig path for the first cluster. Adding `KUADRANT_CONTROL_PLANE__cluster__kubeconfig_path` to the affected tasks ensures both clusters have their kubeconfig paths explicitly available to the testsuite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multicluster and disruptive test execution by ensuring the correct cluster configurations are provided across nightly and release pipelines.
  * Updated cloud-specific multicluster test tasks to use the primary cluster configuration alongside secondary cluster details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->