### PR TITLE
fix: disable the deployment of extensions

### DIFF
--- a/pipelines/deploy/kuadrant-nightly-update/pipeline.yaml
+++ b/pipelines/deploy/kuadrant-nightly-update/pipeline.yaml
@@ -23,10 +23,6 @@ spec:
     name: gateway-crd
     type: string
     default: ""
-  - description: Extensions image to overwrite default one.
-    name: extensions-image
-    type: string
-    default: "quay.io/kuadrant/internal-extensions:latest"
   - description: Additional flags for helm install command, example '--set=kuadrant.installPlanApproval=Manual --set=kuadrant.startingCSV=kuadrant-operator.v1.2.0'
     name: additional-helm-flags
     type: string
@@ -78,8 +74,6 @@ spec:
         value: $(params.operator-name)
       - name: kubeconfig-path
         value: $(tasks.kubectl-login.results.kubeconfig-path)
-      - name: extensions-image
-        value: $(params.extensions-image)
       - name: additional-helm-flags
         value: $(params.additional-helm-flags)
       - name: additional-helm-tools-flags

--- a/pipelines/deploy/kuadrant-testsuite/pipeline.yaml
+++ b/pipelines/deploy/kuadrant-testsuite/pipeline.yaml
@@ -31,10 +31,6 @@ spec:
     name: gateway-crd
     type: string
     default: ""
-  - description: Extensions image to overwrite default one.
-    name: extensions-image
-    type: string
-    default: "quay.io/kuadrant/internal-extensions:latest"
   - description: Additional flags for helm install command, example '--set=kuadrant.installPlanApproval=Manual --set=kuadrant.startingCSV=kuadrant-operator.v1.2.0'
     name: additional-helm-flags
     type: string
@@ -86,8 +82,6 @@ spec:
         value: $(params.operator-name)
       - name: kubeconfig-path
         value: $(tasks.kubectl-login.results.kubeconfig-path)
-      - name: extensions-image
-        value: $(params.extensions-image)
       - name: additional-helm-flags
         value: $(params.additional-helm-flags)
       - name: additional-helm-tools-flags

--- a/pipelines/test/aro/pipeline.yaml
+++ b/pipelines/test/aro/pipeline.yaml
@@ -50,10 +50,6 @@ spec:
       description: GatewayAPI CRD version. [v1.2.1, v1.3.0, v1.4.0] available; leave empty if installing on Openshift 4.19+.
       name: gateway-crd
       type: string
-    - default: "quay.io/kuadrant/internal-extensions:latest"
-      description: Extensions image to overwrite default one.
-      name: extensions-image
-      type: string
     - default: ""
       description: Additional flags for helm install command, example '--set=kuadrant.installPlanApproval=Manual --set=kuadrant.startingCSV=kuadrant-operator.v1.2.0'
       name: additional-helm-flags
@@ -208,8 +204,6 @@ spec:
           value: $(tasks.kubectl-login.results.kubeconfig-path)
         - name: gateway-crd
           value: $(params.gateway-crd)
-        - name: extensions-image
-          value: $(params.extensions-image)
         - name: additional-helm-flags
           value: $(params.additional-helm-flags)
         - name: additional-helm-tools-flags

--- a/pipelines/test/mcp-gateway-osd/pipeline.yaml
+++ b/pipelines/test/mcp-gateway-osd/pipeline.yaml
@@ -117,10 +117,6 @@ spec:
     name: kuadrant-additional-helm-flags
     type: string
     default: ""
-  - description: Extensions image to overwrite default one.
-    name: extensions-image
-    type: string
-    default: "quay.io/kuadrant/internal-extensions:latest"
   - description: Secret name containing additional Helm values manifest (additionalManifests.yaml)
     name: additional-manifests-secret
     type: string
@@ -408,8 +404,6 @@ spec:
         value: $(params.kuadrant-additional-helm-flags)
       - name: additional-manifests-secret
         value: $(params.additional-manifests-secret)
-      - name: extensions-image
-        value: $(params.extensions-image)
     workspaces:
     - name: shared-workspace
   - name: clone-mcp-gateway-repo

--- a/pipelines/test/mcp-gateway/pipeline.yaml
+++ b/pipelines/test/mcp-gateway/pipeline.yaml
@@ -87,10 +87,6 @@ spec:
     name: kuadrant-additional-helm-flags
     type: string
     default: ""
-  - description: Extensions image to overwrite default one.
-    name: extensions-image
-    type: string
-    default: "quay.io/kuadrant/internal-extensions:latest"
 # Report Portal
   - description: Prefix of the launch name saved in Report Portal (nightly, pipeline, etc.)
     name: launch-name
@@ -190,8 +186,6 @@ spec:
         value: $(params.kuadrant-additional-helm-flags)
       - name: additional-manifests-secret
         value: $(params.additional-manifests-secret)
-      - name: extensions-image
-        value: $(params.extensions-image)
     workspaces:
     - name: shared-workspace
       workspace: shared-workspace

--- a/pipelines/test/ocp-aws/pipeline.yaml
+++ b/pipelines/test/ocp-aws/pipeline.yaml
@@ -43,10 +43,6 @@ spec:
       description: GatewayAPI CRD version. [v1.2.1, v1.3.0, v1.4.0] available; leave empty if installing on Openshift 4.19+.
       name: gateway-crd
       type: string
-    - default: "quay.io/kuadrant/internal-extensions:latest"
-      description: Extensions image to overwrite default one.
-      name: extensions-image
-      type: string
     - default: ""
       description: Additional flags for helm install command, example '--set=kuadrant.installPlanApproval=Manual --set=kuadrant.startingCSV=kuadrant-operator.v1.2.0'
       name: additional-helm-flags
@@ -145,8 +141,6 @@ spec:
           value: $(tasks.provision-ocp-aws.results.kubeconfig-path)
         - name: gateway-crd
           value: $(params.gateway-crd)
-        - name: extensions-image
-          value: $(params.extensions-image)
         - name: additional-helm-flags
           value: $(params.additional-helm-flags)
         - name: additional-helm-tools-flags

--- a/pipelines/test/osd-upgrade/pipeline.yaml
+++ b/pipelines/test/osd-upgrade/pipeline.yaml
@@ -62,10 +62,6 @@ spec:
       description: GatewayAPI CRD version. [v1.2.1, v1.3.0, v1.4.0] available; leave empty if installing on Openshift 4.19+.
       name: gateway-crd
       type: string
-    - default: "quay.io/kuadrant/internal-extensions:latest"
-      description: Extensions image to overwrite default one.
-      name: extensions-image
-      type: string
     - default: ""
       description: Additional flags for helm install command, example '--set=kuadrant.installPlanApproval=Manual --set=kuadrant.startingCSV=kuadrant-operator.v1.2.0'
       name: additional-helm-flags
@@ -372,8 +368,6 @@ spec:
           value: $(tasks.kubectl-login.results.kubeconfig-path)
         - name: gateway-crd
           value: $(params.gateway-crd)
-        - name: extensions-image
-          value: $(params.extensions-image)
         - name: additional-helm-flags
           value: $(params.additional-helm-flags)
         - name: additional-helm-tools-flags

--- a/pipelines/test/osd/pipeline.yaml
+++ b/pipelines/test/osd/pipeline.yaml
@@ -62,10 +62,6 @@ spec:
       description: GatewayAPI CRD version. [v1.2.1, v1.3.0, v1.4.0] available; leave empty if installing on Openshift 4.19+.
       name: gateway-crd
       type: string
-    - default: "quay.io/kuadrant/internal-extensions:latest"
-      description: Extensions image to overwrite default one.
-      name: extensions-image
-      type: string
     - default: ""
       description: Additional flags for helm install command, example '--set=kuadrant.installPlanApproval=Manual --set=kuadrant.startingCSV=kuadrant-operator.v1.2.0'
       name: additional-helm-flags
@@ -368,8 +364,6 @@ spec:
           value: $(tasks.kubectl-login.results.kubeconfig-path)
         - name: gateway-crd
           value: $(params.gateway-crd)
-        - name: extensions-image
-          value: $(params.extensions-image)
         - name: additional-helm-flags
           value: $(params.additional-helm-flags)
         - name: additional-helm-tools-flags

--- a/pipelines/test/upgrade/pipeline.yaml
+++ b/pipelines/test/upgrade/pipeline.yaml
@@ -33,10 +33,6 @@ spec:
       description: GatewayAPI CRD version. [v1.2.1, v1.3.0, v1.4.0] available; leave empty if installing on Openshift 4.19+.
       name: gateway-crd
       type: string
-    - default: "quay.io/kuadrant/internal-extensions:latest"
-      description: Extensions image to overwrite default one.
-      name: extensions-image
-      type: string
     - default: "--set=kuadrant.installPlanApproval=Manual --set=kuadrant.startingCSV=rhcl-operator.v1.2.1"
       description: Additional flags for helm install command, update default value for desired "upgrade from" version here as needed
       name: additional-helm-flags
@@ -137,8 +133,6 @@ spec:
           value: $(tasks.kubectl-login.results.kubeconfig-path)
         - name: gateway-crd
           value: $(params.gateway-crd)
-        - name: extensions-image
-          value: $(params.extensions-image)
         - name: additional-helm-flags
           value: $(params.additional-helm-flags)
         - name: additional-helm-tools-flags

--- a/tasks/deploy/helm-deploy.yaml
+++ b/tasks/deploy/helm-deploy.yaml
@@ -28,9 +28,6 @@ spec:
     - description: Additional flags for tools helm, example '--set=tools.keycloak.keycloakProvider=deployment --set=tools.valkey.enable=false'"
       name: additional-helm-tools-flags
       type: string
-    - description: Extensions image to overwrite default one.
-      name: extensions-image
-      type: string
     - description: If set to 'true' tools operators and instances will be installed
       name: install-tools
       type: string
@@ -214,11 +211,10 @@ spec:
         helm install -n=default \
           --repo https://kuadrant.io/helm-charts-olm \
           --values=/mount/values-additional-manifests/additionalManifests.yaml \
-          --values=/mount/values-extensions-manifests/extensionsManifests.yaml \
           --set=kuadrant.indexImage="$(params.index-image)" \
           --set=kuadrant.channel="$(params.channel)" \
           --set=kuadrant.operatorName="$(params.operator-name)" \
-          --set=kuadrant.extensionsImage="$(params.extensions-image)" \
+          --set=kuadrant.extensionsImage="" \
           --set=istio.istioProvider="$(params.istio-provider)" \
           --set=gatewayAPI.version="$(params.gateway-crd)" \
           --set=tools.enabled=true \
@@ -232,8 +228,6 @@ spec:
     volumeMounts:
       - mountPath: /mount/values-additional-manifests
         name: values-additional-manifests
-      - mountPath: /mount/values-extensions-manifests
-        name: values-extensions-manifests
     env:
       - name: KUBECONFIG
         value: $(params.kubeconfig-path)
@@ -272,9 +266,6 @@ spec:
     - secret:
         secretName: $(params.additional-manifests-secret)
       name: values-additional-manifests
-    - configMap:
-        name: values-extensions-manifests
-      name: values-extensions-manifests
       
   workspaces:
   - name: shared-workspace


### PR DESCRIPTION
 Extensions deployment is temporarily disabled until the new deployment workflow is ready.

The extensions CSV patch fails because the Unix socket volume was removed in the TCP migration, leaving no `volumes` or `volumeMounts` arrays in the deployment spec for the JSON patch to append to.

  ### Changes
  - Removed `extensions-image` parameter from all pipelines and the `helm-deploy` task
  - Explicitly set `extensionsImage` to empty to override the helm chart default

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the obsolete extensions image configuration from deployment and testing workflows.
  * Simplified operator installation by removing extensions manifest mounting and configuration.
  * Existing deployment parameters and additional manifest handling remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->