### PR TITLE
MCPGatewayExtension schema version bump

### DIFF
--- a/tasks/test/mcp/after-e2e-setup.yaml
+++ b/tasks/test/mcp/after-e2e-setup.yaml
@@ -116,7 +116,7 @@ spec:
 
         # Create MCPGatewayExtension
         kubectl apply -n $(params.mcp-gateway-namespace) -f - <<EOF
-        apiVersion: mcp.kuadrant.io/v1alpha1
+        apiVersion: mcp.kuadrant.io/v1
         kind: MCPGatewayExtension
         metadata:
           name: mcp-gateway-extension


### PR DESCRIPTION
MCPGatewayExtension schema version bump

The v1alpha1 is no longer served since https://github.com/Kuadrant/mcp-gateway/issues/1376 got addressed recently.

### Verification Steps
Given the scope eye review should suffice